### PR TITLE
Cleanup git-lfs installation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get -y update && \
 
 RUN curl -sSOL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh && \
 	bash script.deb.sh && \
-	apt-get install -y git-lfs && \
-	git lfs install
+	rm script.deb.sh && \
+	apt-get install -y git-lfs
 
 ################################################################################
 #


### PR DESCRIPTION
- Remove PPA script.
- Do not install git-lfs hooks, they are useless for the root user.

Signed-off-by: David Calavera <david.calavera@gmail.com>