### PR TITLE
Add Git LFS filters and fetching rules.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,5 +228,6 @@ RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add buildscript for local testing
 ADD run-build.sh /usr/local/bin/build
+ADD buildbot-git-config /opt/buildhome/.gitconfig
 
 USER buildbot

--- a/buildbot-git-config
+++ b/buildbot-git-config
@@ -1,0 +1,6 @@
+[lfs]
+	fetchinclude = *.jpg,*.png,*.svg,*.gif,*.pdf,*.mp4
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	required = true


### PR DESCRIPTION
Allow to only download things that web sites use the most.
That way the cache that we generate is not full of assets that we're not going to serve.

See git-lfs-fetch for more information about include rules:

https://github.com/github/git-lfs/blob/7472995bcf0900c79ec6ae2d1fe86610b599744b/docs/man/git-lfs-fetch.1.ronn#L37

Signed-off-by: David Calavera <david.calavera@gmail.com>