### PR TITLE
Install Yarn and Elm in the base build image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,8 @@ RUN /bin/bash -c '. ~/.nvm/nvm.sh && nvm install 4 && nvm use 4 && \
     npm install -g sm && \
     npm install -g grunt-cli && \
     npm install -g bower && \
-    npm install -g elm'
+    npm install -g elm && \
+    npm install -g yarn'
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,10 @@ USER buildbot
 RUN git clone https://github.com/creationix/nvm.git ~/.nvm
 
 RUN /bin/bash -c '. ~/.nvm/nvm.sh && nvm install 4 && nvm use 4 && \
-    npm install -g sm && npm install -g grunt-cli && npm install -g bower'
+    npm install -g sm && \
+    npm install -g grunt-cli && \
+    npm install -g bower && \
+    npm install -g elm'
 
 USER root
 


### PR DESCRIPTION
So people can use Yarn to install packages and we can also build Elm projects.

We still need to check if our cache will work as expected with Yarn, but we'll need to do this anyways.