### PR TITLE
Update pre-installed Rubies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,14 +98,13 @@ RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.1.9 && rvm use 2.1.9 && gem install bundler && \
-                  rvm install 2.1.10 && rvm use 2.1.10 && gem install bundler && \
-                  rvm install 2.2.5 && rvm use 2.2.5 && gem install bundler && \
                   rvm install 2.2.6 && rvm use 2.2.6 && gem install bundler && \
-                  rvm install 2.3.2 && rvm use 2.3.2 && gem install bundler && \
+                  rvm install 2.2.7 && rvm use 2.2.7 && gem install bundler && \
                   rvm install 2.3.3 && rvm use 2.3.3 && gem install bundler && \
+                  rvm install 2.3.4 && rvm use 2.3.4 && gem install bundler && \
                   rvm install 2.4.0 && rvm use 2.4.0 && gem install bundler && \
-                  rvm use 2.1.10 --default && rvm cleanup all"
+                  rvm install 2.4.1 && rvm use 2.4.1 && gem install bundler && \
+                  rvm use 2.2.7 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,15 +98,14 @@ RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.0.0-p247 && rvm use 2.0.0-p247 && gem install bundler && \
-                  rvm install 2.1.2 && rvm use 2.1.2 && gem install bundler && \
-                  rvm install 2.2.1 && rvm use 2.2.1 && gem install bundler && \
-                  rvm install 2.2.3 && rvm use 2.2.3 && gem install bundler && \
-                  rvm install 2.3.0 && rvm use 2.3.0 && gem install bundler && \
-                  rvm install 2.3.1 && rvm use 2.3.1 && gem install bundler && \
+                  rvm install 2.1.9 && rvm use 2.1.9 && gem install bundler && \
+                  rvm install 2.1.10 && rvm use 2.1.10 && gem install bundler && \
+                  rvm install 2.2.5 && rvm use 2.2.5 && gem install bundler && \
+                  rvm install 2.2.6 && rvm use 2.2.6 && gem install bundler && \
+                  rvm install 2.3.2 && rvm use 2.3.2 && gem install bundler && \
                   rvm install 2.3.3 && rvm use 2.3.3 && gem install bundler && \
                   rvm install 2.4.0 && rvm use 2.4.0 && gem install bundler && \
-                  rvm use 2.1.2 --default && rvm cleanup all"
+                  rvm use 2.1.10 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USER root

--- a/run-build.sh
+++ b/run-build.sh
@@ -45,7 +45,7 @@ source $HOME/.rvm/scripts/rvm
 export RUBY_VERSION=2.1.10
 if [[ -f .ruby-version ]]; then
 	desired_ruby_version=$(cat .ruby-version)
-	if rvm install "$desired_ruby_version" && rvm use "$desired_ruby_version"; then
+	if rvm use "$desired_ruby_version" --install --binary --fuzzy; then
 		echo "Using Ruby ${desired_ruby_version} specified in .ruby-version"
 		export RUBY_VERSION="$desired_ruby_version"
 	else

--- a/run-build.sh
+++ b/run-build.sh
@@ -42,7 +42,7 @@ export NODE_VERSION=$NODE_VERSION
 
 # Ruby version
 source $HOME/.rvm/scripts/rvm
-export RUBY_VERSION=2.1.10
+export RUBY_VERSION=2.2.7
 if [[ -f .ruby-version ]]; then
 	desired_ruby_version=$(cat .ruby-version)
 	if rvm use "$desired_ruby_version" --install --binary --fuzzy; then

--- a/run-build.sh
+++ b/run-build.sh
@@ -42,14 +42,15 @@ export NODE_VERSION=$NODE_VERSION
 
 # Ruby version
 source $HOME/.rvm/scripts/rvm
-export RUBY_VERSION=2.1.2
+export RUBY_VERSION=2.1.10
 if [[ -f .ruby-version ]]; then
-	if rvm use $(cat .ruby-version); then
-		echo "Set ruby from .ruby-version"
-		export RUBY_VERSION=$(cat .ruby-version)
+	desired_ruby_version=$(cat .ruby-version)
+	if rvm install "$desired_ruby_version" && rvm use "$desired_ruby_version"; then
+		echo "Using Ruby ${desired_ruby_version} specified in .ruby-version"
+		export RUBY_VERSION="$desired_ruby_version"
 	else
-		echo "Error setting ruby version from .ruby-version file. Unsupported version?"
-		echo "Will use default version (2.1.2)"
+		echo "Failed to install/use Ruby ${desired_ruby_version} specified in .ruby-version"
+		echo "Will use default version (${RUBY_VERSION})"
 		rvm use $RUBY_VERSION
 	fi
 else


### PR DESCRIPTION
The [Ruby downloads page](https://www.ruby-lang.org/en/downloads/) lists the latest supported versions of Ruby:

>#### Stable releases:
> - Ruby 2.4.1
> - Ruby 2.3.4
>
>#### In security maintenance phase (will EOL soon!):
> - Ruby 2.2.7
>
>#### Not maintained anymore (EOL):
> - Ruby 2.1.10

This PR:
 - Drops `2.0.x` and `2.1.x`
 - For each supported branch, adds the latest stable Ruby, and the `current_version - 1`.
 - Sets the RVM "default" Ruby to `2.2.7` (the oldest version which is still officially supported)
 - Allows for other non-preinstalled Rubies to be installed on the fly at site build time.