### PR TITLE
Electron support through xvfb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get -y update && \
                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff5-dev \
                       pandoc libsm6 libxrender1 libfontconfig1 libgmp3-dev \
                       libexif-dev swig python3 python3-dev libgd-dev default-jdk \
-                      php5-cli php5-cgi libmcrypt-dev strace && \
+                      php5-cli php5-cgi libmcrypt-dev strace \
+		      libgtk2.0-0 libgconf-2-4 libasound2 libxtst6 libxss1 libnss3 xvfb && \
     apt-get clean
 
 RUN curl -sSOL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh && \


### PR DESCRIPTION
We're making heavy use of Electron (through [Nightmare](https://github.com/segmentio/nightmare))  for [build-time pre-rendering](https://github.com/graphcool/prep) and UI testing. Currently we're running all of our build code on Circle but it would be great if we could migrate more and more directly to Netlify this way.

To make Electron work inside of docker an additional dependency (`xvfb`) is required. You can find more information about this here: https://github.com/segmentio/nightmare/issues/224