### PR TITLE
Add graphviz for Sphinx users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && \
                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff5-dev \
                       pandoc libsm6 libxrender1 libfontconfig1 libgmp3-dev \
                       libexif-dev swig python3 python3-dev libgd-dev default-jdk \
-                      php5-cli php5-cgi libmcrypt-dev strace && \
+                      php5-cli php5-cgi libmcrypt-dev strace graphviz && \
     apt-get clean
 
 RUN curl -sSOL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh && \


### PR DESCRIPTION
Currently anyone who includes a dependency chart or graph in their Sphinx documentation cannot post to your site. Adding graphviz means that Sphinx can build them, rather than have garbled text in your page.