### PR TITLE
Fixed Python 3 virtual environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,11 +152,11 @@ RUN virtualenv -p python2.7 --no-site-packages /opt/buildhome/python2.7 && \
 
 RUN virtualenv -p python3.4 --no-site-packages /opt/buildhome/python3.4 && \
     /bin/bash -c 'source /opt/buildhome/python3.4/bin/activate' && \
-    ln -nfs /opt/buildhome/python3.4.0 /opt/buildhome/python3.4.0
+    ln -nfs /opt/buildhome/python3.4 /opt/buildhome/python3.4.0
 
 RUN virtualenv -p python3.5 --no-site-packages /opt/buildhome/python3.5 && \
     /bin/bash -c 'source /opt/buildhome/python3.5/bin/activate' && \
-    ln -nfs /opt/buildhome/python3.5.2 /opt/buildhome/python3.5.2
+    ln -nfs /opt/buildhome/python3.5 /opt/buildhome/python3.5.2
 
 USER root
 


### PR DESCRIPTION
Setting the Python version to `3.4.0` or `3.5.2` via `runtime.txt` did not work as documented on
https://www.netlify.com/docs/continuous-deployment/#set-node-ruby-or-python-version

The switch aborted with an error "Too many levels of symbolic links". Fixed the symlink creation which pointed back to itself instead the actual directory.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>