### PR TITLE
Use binrc to install new Hugo versions on demand.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,12 @@ USER root
 #
 ################################################################################
 
+ENV BINRC_VERSION 0.1.1
+
+RUN mkdir /opt/binrc && cd /opt/binrc && \
+    curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \
+    ln -s /opt/binrc/binrc_${BINRC_VERSION}_linux_amd64/binrc_${BINRC_VERSION}_linux_amd64 /usr/local/bin/binrc
+
 RUN mkdir /opt/hugo && cd /opt/hugo && \
     curl -sL https://github.com/spf13/hugo/releases/download/v0.13/hugo_0.13_linux_amd64.tar.gz | tar zxvf - && \
     ln -s /opt/hugo/hugo_0.13_linux_amd64/hugo_0.13_linux_amd64 /usr/local/bin/hugo_0.13 && \

--- a/run-build.sh
+++ b/run-build.sh
@@ -102,8 +102,17 @@ fi
 
 # Leiningen
 if [[ -f project.clj ]]; then
-  if lein deps; then
+	if lein deps; then
 		echo "Leiningen dependencies installed"
+	fi
+fi
+
+# Hugo
+if [[ -n "$HUGO_VERSION" ]]; then
+	hugoPath=$(binrc install hugo)
+	if [[ $? -eq 0 ]]; then
+		export PATH=$(dirname $hugoPath):$PATH
+		echo "Hugo ${HUGO_VERSION} installed"
 	fi
 fi
 


### PR DESCRIPTION
Rather than adding every single version of Hugo to the base image,
from now on, users can install new versions of Hugo by setting
the HUGO_VERSION variable in their environments.

Binrc is a small program that will take that version and download the binary on demand. See more details in its repository:

https://github.com/netlify/binrc

Example: 

```
HUGO_VERSION 0.20 binrc install hugo
```

Signed-off-by: David Calavera <david.calavera@gmail.com>