### PR TITLE
Update binrc to fix issues with newer versions of Hugo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,7 @@ USER root
 #
 ################################################################################
 
-ENV BINRC_VERSION 0.1.1
+ENV BINRC_VERSION 0.2.0
 
 RUN mkdir /opt/binrc && cd /opt/binrc && \
     curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \


### PR DESCRIPTION
This updates binrc to 0.2.0 to work with newer versions of Hugo
and their changes to their release tarballs.

https://github.com/netlify/binrc/releases/tag/v0.2.0

Signed-off-by: David Calavera <david.calavera@gmail.com>