### PR TITLE
mount the run-build-functions.sh as a file

### DIFF
--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -5,5 +5,5 @@ REPO_PATH=$(cd $1 &&  pwd)
 
 docker run --rm -t -i \
 	-v ${REPO_PATH}:/opt/repo \
-	-v ${BASE_PATH}/run-build-function.sh:/usr/local/bin/ \
+	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
 	netlify/build /bin/bash


### PR DESCRIPTION
we were overwriting the /usr/local/bin/ when we just wanted to just add that file