### PR TITLE
Update OpenJDK to OpenJDK 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,12 @@ RUN apt-get -y update && \
                       gobject-introspection gtk-doc-tools libglib2.0-dev \
                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff5-dev \
                       pandoc libsm6 libxrender1 libfontconfig1 libgmp3-dev \
-                      libexif-dev swig python3 python3-dev libgd-dev default-jdk \
+                      libexif-dev swig python3 python3-dev libgd-dev software-properties-common \
                       php5-cli php5-cgi libmcrypt-dev strace libgtk2.0-0 libgconf-2-4 \
                       libasound2 libxtst6 libxss1 libnss3 xvfb graphviz && \
+    add-apt-repository ppa:openjdk-r/ppa && \
+    apt-get -y update && \
+    apt-get install -y openjdk-8-jdk && \
     apt-get clean
 
 RUN curl -sSOL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh && \


### PR DESCRIPTION
We've got some software that requires Java 8 to build on Netlify.

Java 7 was publicly EOLed in 2015, and Java 9 is coming out later this year. However, it is looking unlikely that Ubuntu 14.04 will ever support Java 8. It also sounds like Netlify is going to stick with Ubuntu 14.04 for the foreseeable future. Therefore, since the Ubuntu OpenJDK team **has** packaged Java 8 for Ubuntu 14.04, this PR makes use of their PPA to get Java 8.

I have removed the `default-jdk` package (which pulls in Java 7) and am using `openjdk-8-jdk` in order to preserve existing functionality (JRE vs JDK) to the extent possible. I understand Java was only added in the first place in order to support Clojure (which, incidentally, is what I am using as well), so I don't see a problem with bumping the Java version to Java 8, as Java 8 works just fine with all Clojure build tools, and there is no promise from Netlify (that I could find) to support any particular version of Java.

`software-properties-common` is necessary for `add-apt-repository`.

Thread of users asking for Java 8 in Ubuntu 14.04:

https://bugs.launchpad.net/trusty-backports/+bug/1368094

PPA that this PR makes use of:

https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa

Before the PR:

```
java -version
java version "1.7.0_121"
OpenJDK Runtime Environment (IcedTea 2.6.8) (7u121-2.6.8-1ubuntu0.14.04.3)
OpenJDK 64-Bit Server VM (build 24.121-b00, mixed mode)
```

After the PR:

```
java -version
openjdk version "1.8.0_111"
OpenJDK Runtime Environment (build 1.8.0_111-8u111-b14-3~14.04.1-b14)
OpenJDK 64-Bit Server VM (build 25.111-b14, mixed mode)
```