### PR TITLE
Add Emacs Cask support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -251,14 +251,14 @@ RUN /bin/bash -c 'phpbrew init && source ~/.phpbrew/bashrc && phpbrew install 5.
 #
 ################################################################################
 USER root
-
-RUN wget http://ftpmirror.gnu.org/emacs/emacs-25.2.tar.gz && \
-    tar -xf emacs-25.2.tar.gz && \
-    cd emacs-25.2 && \
+ENV EMACS_VERSION 25.3
+RUN wget http://ftpmirror.gnu.org/emacs/emacs-${EMACS_VERSION}.tar.gz && \
+    tar -xf emacs-${EMACS_VERSION}.tar.gz && \
+    cd emacs-${EMACS_VERSION} && \
     env CANNOT_DUMP=yes ./configure --without-x && \
     make install && \
     make clean && \
-    cd .. && rm -rf emacs-25.2 emacs-25.2.tar.gz
+    cd .. && rm -rf emacs-${EMACS_VERSION} emacs-${EMACS_VERSION}.tar.gz
 
 USER buildbot
 RUN rm -rf /opt/buildhome/.cask && git clone https://github.com/cask/cask.git /opt/buildhome/.cask

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,13 +247,19 @@ RUN /bin/bash -c 'phpbrew init && source ~/.phpbrew/bashrc && phpbrew install 5.
 
 ################################################################################
 #
-# Emacs Cask
+# Emacs and Cask
 #
 ################################################################################
 USER root
-RUN add-apt-repository ppa:kelleyk/emacs
-RUN apt-get -y update
-RUN apt-get -y install emacs25-nox
+
+RUN wget http://ftpmirror.gnu.org/emacs/emacs-25.2.tar.gz && \
+    tar -xf emacs-25.2.tar.gz && \
+    cd emacs-25.2 && \
+    env CANNOT_DUMP=yes ./configure --without-x && \
+    make install && \
+    make clean && \
+    cd .. && rm -rf emacs-25.2 emacs-25.2.tar.gz
+
 USER buildbot
 RUN rm -rf /opt/buildhome/.cask && git clone https://github.com/cask/cask.git /opt/buildhome/.cask
 ENV PATH "$PATH:/opt/buildhome/.cask/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,9 +245,21 @@ USER buildbot
 RUN /bin/bash -c 'phpbrew init && source ~/.phpbrew/bashrc && phpbrew install 5.6 +default && \
     phpbrew app get composer'
 
+################################################################################
+#
+# Emacs Cask
+#
+################################################################################
 USER root
+RUN add-apt-repository ppa:kelleyk/emacs
+RUN apt-get -y update
+RUN apt-get -y install emacs25-nox
+USER buildbot
+RUN rm -rf /opt/buildhome/.cask && git clone https://github.com/cask/cask.git /opt/buildhome/.cask
+ENV PATH "$PATH:/opt/buildhome/.cask/bin"
 
 # Cleanup
+USER root
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && apt-get autoremove -y
 
 # Add buildscript for local testing

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -326,6 +326,16 @@ install_dependencies() {
       export PATH=$(dirname $hugoPath):$PATH
     fi
   fi
+
+  # Cask
+  if [ -n "Cask" ]
+  then
+    cask install
+    if [ $? -eq 0 ]
+    then
+      echo "Emacs packages installed"
+    fi
+  fi
 }
 
 #
@@ -373,6 +383,11 @@ cache_artifacts() {
     rm -rf $NETLIFY_CACHE_DIR/node_version
     mkdir $NETLIFY_CACHE_DIR/node_version
     mv $NVM_DIR/versions/node/$NODE_VERSION $NETLIFY_CACHE_DIR/node_version/
+  fi
+
+  if [ -d .cask ]
+  then
+    mv $NETLIFY_BUILD_BASE/.cask $NETLIFY_CACHE_DIR/.cask
   fi
 }
 


### PR DESCRIPTION
- [Emacs](https://www.gnu.org/software/emacs/)
- [Cask](https://github.com/cask/cask)

As a Emacs user, I'm using [orgmode](http://orgmode.org/) to generate
my blog. And, I really like switch to netlify from github page
and circleci(emacs will compile orgmode files to html on the CI).

I've really like to have Emacs installed as part of netlify's build
tool(hugo can support partially orgmode parsing, but not native completely
support like emacs), and Cask as package management tool for Emacs.

So I can compile
Emacs orgmode files with command such as `cask exec emacs --batch -l
my-emacs-config.el -f org-publish-all` on netlify build, just like any ruby command `bundle
exec blah`