### PR TITLE
Adding cmake and xsltproc to the set of tools available in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -y update && \
                       pandoc libsm6 libxrender1 libfontconfig1 libgmp3-dev \
                       libexif-dev swig python3 python3-dev libgd-dev software-properties-common \
                       php5-cli php5-cgi libmcrypt-dev strace libgtk2.0-0 libgconf-2-4 \
-                      libasound2 libxtst6 libxss1 libnss3 xvfb graphviz && \
+                      libasound2 libxtst6 libxss1 libnss3 xvfb graphviz cmake xsltproc && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get -y update && \
     apt-get install -y openjdk-8-jdk && \


### PR DESCRIPTION
I'm proposing including cmake and xsltproc (both part of standard Ubuntu distribution) to allow for more flexible site builds. CMake for driving build process, xsltproc as command-line XSLT processor.