### PR TITLE
added pandoc and wkhtmltopdf as dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ RUN apt-get -y update && \
                       pandoc libsm6 libxrender1 libfontconfig1 libgmp3-dev \
                       libexif-dev swig python3 python3-dev libgd-dev software-properties-common \
                       php5-cli php5-cgi libmcrypt-dev strace libgtk2.0-0 libgconf-2-4 \
-                      libasound2 libxtst6 libxss1 libnss3 xvfb graphviz && \
+                      libasound2 libxtst6 libxss1 libnss3 xvfb graphviz pandoc && \
+    add-apt-repository ppa:ecometrica/servers && \
+    apt-get -y update && \
+    apt-get install -y wkhtmltopdf && \                      
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get -y update && \
     apt-get install -y openjdk-8-jdk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,17 @@ RUN apt-get -y update && \
                       libexif-dev swig python3 python3-dev libgd-dev software-properties-common \
                       php5-cli php5-cgi libmcrypt-dev strace libgtk2.0-0 libgtk-3-0 libgconf-2-4 \
                       libasound2 libxtst6 libxss1 libnss3 xvfb graphviz pandoc && \
-    add-apt-repository ppa:ecometrica/servers && \
-    apt-get -y update && \
-    apt-get install -y wkhtmltopdf && \                      
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get -y update && \
     apt-get install -y openjdk-8-jdk && \
     apt-get clean
+
+
+RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz && \
+    tar -xf wkhtmltox-0.12.4_linux-generic-amd64.tar && \
+    cd wkhtmltox && \
+    cp -r ./ /usr/ && \
+    wkhtmltopdf -V
 
 RUN curl -sSOL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh && \
 	bash script.deb.sh && \


### PR DESCRIPTION
Suggested by Chris during the online support,  added these 2 doc converters to the base images, to facilitate building PDF or other formats of certain deployed static pages.

As the default wkhtml2pdf packages for Ubuntu 14.04 were far behind the latest version,  a 3rd-party ppa is used according to this [stackoverflow thread](https://askubuntu.com/questions/556667/how-to-install-wkhtmltopdf-0-12-1-on-ubuntu-server) 