### PR TITLE
Add headless Chrome support with libgtk-3-0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && \
                       libjpeg-turbo8-dev libpng12-dev libwebp-dev libtiff5-dev \
                       pandoc libsm6 libxrender1 libfontconfig1 libgmp3-dev \
                       libexif-dev swig python3 python3-dev libgd-dev software-properties-common \
-                      php5-cli php5-cgi libmcrypt-dev strace libgtk2.0-0 libgconf-2-4 \
+                      php5-cli php5-cgi libmcrypt-dev strace libgtk2.0-0 libgtk-3-0 libgconf-2-4 \
                       libasound2 libxtst6 libxss1 libnss3 xvfb graphviz && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get -y update && \


### PR DESCRIPTION
We are using https://github.com/addyosmani/critical to generate critical CSS as part of the build process. Critical uses headless Chrome behind the scenes, which currently fails on Netlify:

```
5:26:24 PM: (node:866) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Failed to launch chrome!
/opt/build/repo/node_modules/puppeteer/.local-chromium/linux-499413/chrome-linux/chrome: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory


TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
5:26:24 PM: (node:866) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

The only missing part is `libgtk-3-0`. With that installed, it works.