### PR TITLE
Update Binrc version to 0.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,7 @@ USER root
 #
 ################################################################################
 
-ENV BINRC_VERSION 0.2.0
+ENV BINRC_VERSION 0.2.2
 
 RUN mkdir /opt/binrc && cd /opt/binrc && \
     curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \


### PR DESCRIPTION
This version includes a patch to support Gutenberg out of the box.

Signed-off-by: David Calavera <david.calavera@gmail.com>