### PR TITLE
Remove unused command

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -18,7 +18,6 @@ EOF
 mkdir -p $NETLIFY_CACHE_DIR
 rm -rf $NETLIFY_BUILD_BASE/.yarn
 
-cd $NETLIFY_BUILD_BASE
 if [[ ! -d $NETLIFY_REPO_DIR ]]; then
   git clone $NETLIFY_REPO_URL $NETLIFY_REPO_DIR
 fi


### PR DESCRIPTION
The variables on the next two lines use absolute paths, so the current working directory, at this point, is not relevant.

And following that there is another `cd` command, now entering the real relevant directory.