### PR TITLE
Add latest patch release for lowest supported Ruby (2.2) and default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,13 +132,14 @@ RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
                   rvm install 2.1.2 && rvm use 2.1.2 && gem install bundler && \
                   rvm install 2.2.1 && rvm use 2.2.1 && gem install bundler && \
                   rvm install 2.2.3 && rvm use 2.2.3 && gem install bundler && \
+                  rvm install 2.2.8 && rvm use 2.2.8 && gem install bundler && \
                   rvm install 2.3.0 && rvm use 2.3.0 && gem install bundler && \
                   rvm install 2.3.1 && rvm use 2.3.1 && gem install bundler && \
                   rvm install 2.3.3 && rvm use 2.3.3 && gem install bundler && \
                   rvm install 2.4.0 && rvm use 2.4.0 && gem install bundler && \
                   rvm install 2.4.1 && rvm use 2.4.1 && gem install bundler && \
                   rvm install 2.4.2 && rvm use 2.4.2 && gem install bundler && \
-                  rvm use 2.1.2 --default && rvm cleanup all"
+                  rvm use 2.2.8 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USER root


### PR DESCRIPTION
Ruby version 2.1.x reached end of life in March 2017.

As it no longer receives security fixes my thoughts were to default to the lower major Ruby version still supported and the latest available patch. As of today this is 2.2.8.

Question outside of the scope of this pull request, does Netlify have a deprecation plan for 2.1.x and lower?