### PR TITLE
add .emacs.d to cache so each build don't need to reinstall all those packages

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -373,9 +373,20 @@ install_dependencies() {
     fi
   fi
 
+  # Emacs Cache
+  if [ -f $NETLIFY_CACHE_DIR/.emacs.d ]
+  then
+    mv $NETLIFY_CACHE_DIR/.emacs.d $NETLIFY_BUILD_BASE/.emacs.d
+  fi
+
   # Cask
   if [ -f Cask ]
   then
+    if [ -d $NETLIFY_CACHE_DIR/.cask ]
+    then
+      rm -rf $NETLIFY_REPO_DIR/.cask
+      mv $NETLIFY_CACHE_DIR/.cask $NETLIFY_REPO_DIR/.cask
+    fi
     if cask install
     then
       echo "Emacs packages installed"
@@ -434,6 +445,12 @@ cache_artifacts() {
   then
     mv $NETLIFY_BUILD_BASE/.cask $NETLIFY_CACHE_DIR/.cask
   fi
+
+  if [ -d $NETLIFY_BUILD_BASE/.emacs.d ]
+  then
+    mv $NETLIFY_BUILD_BASE/.emacs.d $NETLIFY_CACHE_DIR/.emacs.d
+  fi
+
 }
 
 install_missing_commands() {

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -22,7 +22,7 @@ mkdir -p $NETLIFY_CACHE_DIR/.cache
 install_deps() {
   [ -f $1 ] || return 0
   [ -f $3 ] || return 0
- 
+
   SHA1="$(shasum $1)-$2"
   SHA2="$(cat $3)"
   if [ "$SHA1" == "$SHA2" ]
@@ -170,7 +170,7 @@ install_dependencies() {
   fi
 
   if nvm install $NODE_VERSION
-  then 
+  then
     NODE_VERSION=$(nvm current)
     echo "Using version $NODE_VERSION of node"
     export NODE_VERSION=$NODE_VERSION
@@ -374,7 +374,7 @@ install_dependencies() {
   fi
 
   # Emacs Cache
-  if [ -f $NETLIFY_CACHE_DIR/.emacs.d ]
+  if [ -d $NETLIFY_CACHE_DIR/.emacs.d ]
   then
     mv $NETLIFY_CACHE_DIR/.emacs.d $NETLIFY_BUILD_BASE/.emacs.d
   fi


### PR DESCRIPTION
while #73 is working, we
also need to cache the packages `.emacs.d` if user install packages
with `package.el`.