### PR TITLE
Remove EOL and only support latest patched Rubies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,17 +128,11 @@ RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.0.0-p247 && rvm use 2.0.0-p247 && gem install bundler && \
-                  rvm install 2.1.2 && rvm use 2.1.2 && gem install bundler && \
-                  rvm install 2.2.1 && rvm use 2.2.1 && gem install bundler && \
-                  rvm install 2.2.3 && rvm use 2.2.3 && gem install bundler && \
-                  rvm install 2.3.0 && rvm use 2.3.0 && gem install bundler && \
-                  rvm install 2.3.1 && rvm use 2.3.1 && gem install bundler && \
-                  rvm install 2.3.3 && rvm use 2.3.3 && gem install bundler && \
-                  rvm install 2.4.0 && rvm use 2.4.0 && gem install bundler && \
-                  rvm install 2.4.1 && rvm use 2.4.1 && gem install bundler && \
-                  rvm install 2.4.2 && rvm use 2.4.2 && gem install bundler && \
-                  rvm use 2.1.2 --default && rvm cleanup all"
+                  rvm install 2.2.9 && rvm use 2.2.9 && gem install bundler && \
+                  rvm install 2.3.6 && rvm use 2.3.6 && gem install bundler && \
+                  rvm install 2.4.3 && rvm use 2.4.3 && gem install bundler && \
+                  rvm install 2.5.0 && rvm use 2.5.0 && gem install bundler && \
+                  rvm use 2.4.3 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USER root


### PR DESCRIPTION
> Ruby 2.2 is now under the state of the security maintenance phase, until the end of the March of 2018. After the date, maintenance of Ruby 2.2 will be ended. We recommend you start planning migration to newer versions of Ruby, such as 2.4 or 2.3. — https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/

FWIW Jekyll silently dropped support for Ruby 2.1 and will drop support for 2.2 in next major version.