### PR TITLE
Fallback to .node-version if .nvmrc isn't present

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -157,6 +157,12 @@ install_dependencies() {
   then
     NODE_VERSION=$(cat .nvmrc)
     echo "Using node version '$NODE_VERSION' from .nvmrc"
+  else
+    if [ -f .node-version ]
+    then
+      NODE_VERSION=$(cat .node-version)
+      echo "Using node version '$NODE_VERSION' from .node-version"
+    fi
   fi
 
   if nvm install $NODE_VERSION


### PR DESCRIPTION
Quick attempt to resolve #79 - allowing the use of `.node-version` files when `.nvmrc` isn't present.

https://twitter.com/fool/status/955586493312937984