### PR TITLE
Update build-image to match current defaults for new sites

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -19,7 +19,7 @@ mkdir -p $NETLIFY_CACHE_DIR/.cask
 mkdir -p $NETLIFY_CACHE_DIR/.m2
 mkdir -p $NETLIFY_CACHE_DIR/.boot
 
-: ${YARN_FLAGS="--ignore-optional"}
+: ${YARN_FLAGS=""}
 : ${NPM_FLAGS=""}
 
 install_deps() {

--- a/run-build.sh
+++ b/run-build.sh
@@ -25,9 +25,9 @@ cd $NETLIFY_REPO_DIR
 
 . "$dir/run-build-functions.sh"
 
-: ${NODE_VERSION="6.10.2"}
-: ${RUBY_VERSION="2.1.2"}
-: ${YARN_VERSION="0.18.1"}
+: ${NODE_VERSION="8"}
+: ${RUBY_VERSION="2.2.3"}
+: ${YARN_VERSION="1.3.2"}
 
 echo "Installing dependencies: node=$NODE_VERSION ruby=$RUBY_VERSION yarn=$YARN_VERSION"
 install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -10,9 +10,9 @@
 
 set -e
 
-: ${NODE_VERSION="6"}
-: ${RUBY_VERSION="2.3"}
-: ${YARN_VERSION="0.18.0"}
+: ${NODE_VERSION="8"}
+: ${RUBY_VERSION="2.2.3"}
+: ${YARN_VERSION="1.3.2"}
 : ${NPM_VERSION=""}
 : ${HUGO_VERSION="0.20"}
 


### PR DESCRIPTION
Fixes #128 

I'm curious if we should update Ruby as well, 2.2 is planned to be EOL on 2018-03-31.