### PR TITLE
Add php 7.0 and 7.1 as selectable versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -269,6 +269,7 @@ RUN cd /usr/local/bin && curl -sL -O https://github.com/phpbrew/phpbrew/raw/1.23
 USER buildbot
 
 RUN /bin/bash -c 'phpbrew init && source ~/.phpbrew/bashrc && phpbrew install 5.6 +default && \
+    phpbrew install 7.0 +default && phpbrew install 7.1 +default && \
     phpbrew app get composer'
 
 ################################################################################


### PR DESCRIPTION
PHP 5.5 already reached end of life.
PHP 5.6 and PHP 7.0 only provide security fixes support.
PHP 7.1 is in active support life cycle

Also more and more packages are in the phase of dropping 5.x support.