### PR TITLE
Add webp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         strace \
         swig \
         unzip \
+        webp \
         wget \
         xvfb \
         zip \


### PR DESCRIPTION
Would it be possible to add the `webp` package to the build please?

I am currently using `cwebp` in my build step, but I have to download the binary each time.

(Or is there an easier way to do this, I couldn't figure out how to apt-get install during a build)