### PR TITLE
Add support with Go through Gimme.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -356,6 +356,24 @@ RUN curl -sL https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz | tar xzv
     make install && \
     cd .. && rm -rf lz4-${LZ4_VERSION}
 
+################################################################################
+#
+# Go
+#
+################################################################################
+USER buildbot
+RUN mkdir -p /opt/buildhome/.gimme/bin/ && \
+    mkdir -p /opt/buildhome/.gimme/env/ && \
+    curl -sL -o /opt/buildhome/.gimme/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \
+    chmod u+x /opt/buildhome/.gimme/bin/gimme
+ENV PATH "$PATH:/opt/buildhome/.gimme/bin"
+ENV GOPATH "/opt/buildhome/.gimme_cache/gopath"
+ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
+# Install the default version
+ENV GIMME_GO_VERSION "1.10"
+ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
+RUN gimme
+
 # Cleanup
 USER root
 

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -452,16 +452,24 @@ install_dependencies() {
     local goVersion=$(cat .go-version)
     if [ "$installGoVersion" != "$goVersion" ]
     then
-	installGoVersion="$goVersion"
+      installGoVersion="$goVersion"
     fi
   fi
 
   if [ "$GIMME_GO_VERSION" != "$installGoVersion" ]
   then
-    echo "Installing Go version $goVersion"
-    eval "$(GIMME_ENV_PREFIX=$HOME/.gimme_cache/env GIMME_VERSION_PREFIX=$HOME/.gimme_cache/versions gimme $goVersion)"
+    echo "Installing Go version $installGoVersion"
+    GIMME_ENV_PREFIX=$HOME/.gimme_cache/env GIMME_VERSION_PREFIX=$HOME/.gimme_cache/versions gimme $installGoVersion
+    if [ $? -eq 0 ]
+    then
+      source $HOME/.gimme_cache/env/go$installGoVersion.linux.amd64.env
+    else
+      echo "Failed to install Go version '$isntallGoVersion'"
+      exit 1
+    fi
   else
-    eval "$(gimme)"
+    gimme
+    source $HOME/.gimme/env/go$GIMME_GO_VERSION.linux.amd64.env
   fi
 
   # Setup project GOPATH
@@ -496,7 +504,7 @@ cache_artifacts() {
   then
     unlink $GOPATH/src/$GO_IMPORT_PATH
   fi
-  cache_home_directory ".gimme_cache" "composer dependencies"
+  cache_home_directory ".gimme_cache" "go dependencies"
 
   # cache the version of node installed
   if ! [ -d $NETLIFY_CACHE_DIR/node_version/$NODE_VERSION ]

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -7,6 +7,10 @@ then
   set -x
 fi
 
+export GIMME_TYPE=binary
+export GIMME_NO_ENV_ALIAS=true
+export GIMME_CGO_ENABLED=true
+
 export NVM_DIR="$HOME/.nvm"
 export RVM_DIR="$HOME/.rvm"
 
@@ -30,6 +34,8 @@ mkdir -p $NETLIFY_CACHE_DIR/.emacs.d
 mkdir -p $NETLIFY_CACHE_DIR/.m2
 mkdir -p $NETLIFY_CACHE_DIR/.boot
 mkdir -p $NETLIFY_CACHE_DIR/.composer
+mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gopath
+mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gocache
 
 : ${YARN_FLAGS=""}
 : ${NPM_FLAGS=""}
@@ -139,6 +145,7 @@ install_dependencies() {
   local defaultRubyVersion=$2
   local defaultYarnVersion=$3
   local defaultPHPVersion=$4
+  local installGoVersion=$5
 
   # Python Version
   if [ -f runtime.txt ]
@@ -437,6 +444,33 @@ install_dependencies() {
     restore_home_cache ".composer" "composer dependencies"
     composer install
   fi
+
+  # Go version
+  restore_home_cache ".gimme_cache" "go cache"
+  if [ -f .go-version ]
+  then
+    local goVersion=$(cat .go-version)
+    if [ "$installGoVersion" != "$goVersion" ]
+    then
+	installGoVersion="$goVersion"
+    fi
+  fi
+
+  if [ "$GIMME_GO_VERSION" != "$installGoVersion" ]
+  then
+    echo "Installing Go version $goVersion"
+    eval "$(GIMME_ENV_PREFIX=$HOME/.gimme_cache/env GIMME_VERSION_PREFIX=$HOME/.gimme_cache/versions gimme $goVersion)"
+  else
+    eval "$(gimme)"
+  fi
+
+  # Setup project GOPATH
+  if [ -n "$GO_IMPORT_PATH" ]
+  then
+    mkdir -p "$(dirname $GOPATH/src/$GO_IMPORT_PATH)"
+    rm -rf $GOPATH/src/$GO_IMPORT_PATH
+    ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
+  fi
 }
 
 #
@@ -454,6 +488,15 @@ cache_artifacts() {
   cache_home_directory ".m2" "maven dependencies"
   cache_home_directory ".boot" "boot dependencies"
   cache_home_directory ".composer" "composer dependencies"
+
+
+  # Don't follow the Go import path or we'll store
+  # the origin repo twice.
+  if [ -n "$GO_IMPORT_PATH" ]
+  then
+    unlink $GOPATH/src/$GO_IMPORT_PATH
+  fi
+  cache_home_directory ".gimme_cache" "composer dependencies"
 
   # cache the version of node installed
   if ! [ -d $NETLIFY_CACHE_DIR/node_version/$NODE_VERSION ]
@@ -515,5 +558,12 @@ install_missing_commands() {
       npm install grunt-cli
       export PATH=$(npm bin):$PATH
     fi
+  fi
+}
+
+verify_run_dir() {
+  if [ -n "$GO_IMPORT_PATH" ]
+  then
+    echo "$GOPATH/src/$GO_IMPORT_PATH"
   fi
 }

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -464,12 +464,18 @@ install_dependencies() {
     then
       source $HOME/.gimme_cache/env/go$installGoVersion.linux.amd64.env
     else
-      echo "Failed to install Go version '$isntallGoVersion'"
+      echo "Failed to install Go version '$installGoVersion'"
       exit 1
     fi
   else
     gimme
-    source $HOME/.gimme/env/go$GIMME_GO_VERSION.linux.amd64.env
+    if [ $? -eq 0 ]
+    then
+      source $HOME/.gimme/env/go$GIMME_GO_VERSION.linux.amd64.env
+    else
+      echo "Failed to install Go version '$GIMME_GO_VERSION'"
+      exit 1
+    fi
   fi
 
   # Setup project GOPATH

--- a/run-build.sh
+++ b/run-build.sh
@@ -29,12 +29,20 @@ cd $NETLIFY_REPO_DIR
 : ${RUBY_VERSION="2.3.6"}
 : ${YARN_VERSION="1.3.2"}
 : ${PHP_VERSION="5.6"}
+: ${GO_VERSION="1.10"}
 
-echo "Installing dependencies: node=$NODE_VERSION ruby=$RUBY_VERSION yarn=$YARN_VERSION php=$PHP_VERSION"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION
+echo "Installing dependencies: node=$NODE_VERSION ruby=$RUBY_VERSION yarn=$YARN_VERSION php=$PHP_VERSION go=$GO_VERSION"
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION
 
 echo "Installing missing commands"
 install_missing_commands
+
+echo "Verify run directory"
+run_dir=`verify_run_dir`
+if [ "$run_dir" != "" ]
+then
+  cd $run_dir
+fi
 
 echo "Executing user command: $cmd"
 $cmd

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -10,6 +10,7 @@ docker run --rm -t -i \
 	-e YARN_VERSION \
 	-e HUGO_VERSION \
 	-e PHP_VERSION \
+	-e GO_VERSION \
 	-v ${REPO_PATH}:/opt/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -8,14 +8,21 @@
 # Example with previous cached build:
 #	T=/tmp/cache script/test-build.sh ../netlify-cms 'npm run build'
 
+if [ $NETLIFY_VERBOSE ]
+then
+  set -x
+fi
+
 set -e
 
+: ${NETLIFY_IMAGE="netlify/build"}
 : ${NODE_VERSION="8"}
 : ${RUBY_VERSION="2.3.6"}
 : ${YARN_VERSION="1.3.2"}
 : ${NPM_VERSION=""}
 : ${HUGO_VERSION="0.20"}
 : ${PHP_VERSION="5.6"}
+: ${GO_VERSION="1.10"}
 
 REPO_URL=$1
 
@@ -30,6 +37,7 @@ echo "Using temp dir: $T"
 chmod +w $T
 mkdir -p $T/scripts
 mkdir -p $T/cache
+chmod a+w $T/cache
 
 cp run-build* $T/scripts
 chmod +x $T/scripts/*
@@ -46,9 +54,12 @@ docker run --rm \
 	-e "NPM_VERSION=$NPM_VERSION" \
 	-e "HUGO_VERSION=$HUGO_VERSION" \
 	-e "PHP_VERSION=$PHP_VERSION" \
+	-e "NETLIFY_VERBOSE=$NETLIFY_VERBOSE" \
+	-e "GO_VERSION=$GO_VERSION" \
+	-e "GO_IMPORT_PATH=$GO_IMPORT_PATH" \
 	-v $PWD/$T/scripts:/opt/buildhome/scripts \
 	-v $PWD/$T/repo:/opt/buildhome/repo \
 	-v $PWD/$T/cache:/opt/buildhome/cache \
 	-w /opt/build \
 	-it \
-	netlify/build $SCRIPT
+	$NETLIFY_IMAGE $SCRIPT


### PR DESCRIPTION
- Install the most recent version and allow to install new versions on demand.
- Setup the project in the GOPATH when GO_IMPORT_PATH is set.
- Cache user versions.
- Cache user gopath.

This will allow us to support building Go functions for AWS lambda.

Signed-off-by: David Calavera <david.calavera@gmail.com>