### PR TITLE
recently changed so you need both or grunt-cli won't "run"

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -512,7 +512,7 @@ install_missing_commands() {
   then
     if ! [ $(which grunt) ]
     then
-      npm install grunt-cli
+      npm install grunt-cli grunt
       export PATH=$(npm bin):$PATH
     fi
   fi


### PR DESCRIPTION
we aren't sure when it changed, but the effect of "relying" on our grunt installation now is this:

```
3:02:05 PM: Executing user command: grunt
3:02:05 PM: grunt-cli: The grunt command line interface (v1.2.0)
3:02:05 PM: Fatal error: Unable to find local grunt.
3:02:05 PM: If you're seeing this message, grunt hasn't been installed locally to
3:02:05 PM: your project. For more information about installing and configuring grunt,
3:02:05 PM: please see the Getting Started guide:
3:02:05 PM: http://gruntjs.com/getting-started
```