### PR TITLE
Add an option to skip caching node_modules

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -146,6 +146,7 @@ install_dependencies() {
   local defaultYarnVersion=$3
   local defaultPHPVersion=$4
   local installGoVersion=$5
+  local cacheNodeModules=$6
 
   # Python Version
   if [ -f runtime.txt ]
@@ -187,7 +188,7 @@ install_dependencies() {
   fi
 
   if nvm install $NODE_VERSION
-  then 
+  then
     NODE_VERSION=$(nvm current)
     # no echo needed because nvm does that for us
     export NODE_VERSION=$NODE_VERSION
@@ -261,7 +262,7 @@ install_dependencies() {
       exit 1
     fi
   fi
-  
+
   if ! gem list -i "^bundler$" > /dev/null 2>&1
   then
     if ! gem install bundler
@@ -330,7 +331,11 @@ install_dependencies() {
 
   if [ -f package.json ]
   then
-    restore_cwd_cache node_modules "node modules"
+    if [ "$cacheNodeModules" = true ]
+    then
+      restore_cwd_cache node_modules "node modules"
+    fi
+
     if [ -f yarn.lock ]
     then
       run_yarn $YARN_VERSION
@@ -491,9 +496,15 @@ install_dependencies() {
 # Take things installed during the build and cache them
 #
 cache_artifacts() {
+  local cacheNodeModules=$1
+
   cache_cwd_directory ".bundle" "ruby gems"
   cache_cwd_directory "bower_components" "bower components"
-  cache_cwd_directory "node_modules" "node modules"
+
+  if [ "$cacheNodeModules" = true ]
+  then
+    cache_cwd_directory "node_modules" "node modules"
+  fi
 
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache" "pip cache"

--- a/run-build.sh
+++ b/run-build.sh
@@ -30,9 +30,10 @@ cd $NETLIFY_REPO_DIR
 : ${YARN_VERSION="1.3.2"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.10"}
+: ${CACHE_NODE_MODULES=true}
 
 echo "Installing dependencies: node=$NODE_VERSION ruby=$RUBY_VERSION yarn=$YARN_VERSION php=$PHP_VERSION go=$GO_VERSION"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $CACHE_NODE_MODULES
 
 echo "Installing missing commands"
 install_missing_commands
@@ -49,6 +50,6 @@ $cmd
 CODE=$?
 
 echo "Caching artifacts"
-cache_artifacts
+cache_artifacts $CACHE_NODE_MODULES
 
 exit $CODE

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -23,6 +23,7 @@ set -e
 : ${HUGO_VERSION="0.20"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.10"}
+: ${CACHE_NODE_MODULES=true}
 
 REPO_URL=$1
 
@@ -57,6 +58,7 @@ docker run --rm \
 	-e "NETLIFY_VERBOSE=$NETLIFY_VERBOSE" \
 	-e "GO_VERSION=$GO_VERSION" \
 	-e "GO_IMPORT_PATH=$GO_IMPORT_PATH" \
+	-e "CACHE_NODE_MODULES=$CACHE_NODE_MODULES" \
 	-v $PWD/$T/scripts:/opt/buildhome/scripts \
 	-v $PWD/$T/repo:/opt/buildhome/repo \
 	-v $PWD/$T/cache:/opt/buildhome/cache \


### PR DESCRIPTION
**Why?**
Some packages do not expect the `node_modules` directory to be cached and
have trouble installing themselves a second time. 

Most recently we have been unable to build a project that contains [sharp](https://www.npmjs.com/package/sharp) which has a compilation step that stores data outside of the `node_modules` directory. We have to manually force a build wit a cleared cache each time.  In the past  we have had similar issues with [node-sass](https://www.npmjs.com/package/node-sass).

**What changed?**
If the `$CACHE_NODE_MODULES` environmental variable is `false` the build will skip
caching or attempting to use a cached `node_modules` directory. If
`$CACHE_NODE_MODULES` is unset or `true` then `node_modules` will continue to
be cached.

