### PR TITLE
Support Pipfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The specific patch versions included will depend on when the image was last buil
   * 6
   * 8 (default)
   * Any version that `nvm` can install.
-* Python - `runtime.txt`
+* Python - `runtime.txt` or `Pipfile`
   * 2.7 (default)
   * 3.4
   * 3.5
@@ -46,6 +46,8 @@ The specific patch versions included will depend on when the image was last buil
 * Python
   * pip
     * Version corresponding with Python version. (default)
+  * Pipenv
+    * Latest version.
 * PHP
   * Composer
 * Emacs

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -14,6 +14,10 @@ export GIMME_CGO_ENABLED=true
 export NVM_DIR="$HOME/.nvm"
 export RVM_DIR="$HOME/.rvm"
 
+# Pipenv configuration
+export PIPENV_RUNTIME=3.6
+export WORKON_HOME=$NETLIFY_CACHE_DIR/.pipenv
+
 YELLOW="\033[0;33m"
 NC="\033[0m" # No Color
 
@@ -159,6 +163,10 @@ install_dependencies() {
       echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
       exit 1
     fi
+  elif [ -f Pipfile ]
+  then
+    echo "Found Pipfile installing Pipenv"
+    $HOME/python$PIPENV_RUNTIME/bin/pip install pipenv
   else
     source $HOME/python2.7/bin/activate
   fi
@@ -321,6 +329,24 @@ install_dependencies() {
       echo "Pip dependencies installed"
     else
       echo "Error installing pip dependencies"
+      exit 1
+    fi
+  elif [ -f Pipfile ]
+  then
+    echo "Installing dependencies from Pipfile"
+    if $HOME/python$PIPENV_RUNTIME/bin/pipenv install
+    then
+      echo "Pipenv dependencies installed"
+      if source $($HOME/python$PIPENV_RUNTIME/bin/pipenv --venv)/bin/activate
+      then
+        echo "Python version set to $(python -V)"
+      else
+        echo "Error activating Pipenv environment"
+        echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
+        exit 1
+      fi
+    else
+      echo "Error installing Pipenv dependencies"
       exit 1
     fi
   fi


### PR DESCRIPTION
As mentioned in #151 python community is heavily adopting dependency manager Pipenv. It's even recommended in official guide [Managing Application Dependencies](https://packaging.python.org/tutorials/managing-dependencies/#managing-dependencies). It combines virtualenv creation, runtime specification, dependencies and their locked versions into two files.

I added support for `Pipfile`. The script first checks for `runtime.txt` and then for `Pipfile`.

You can test the implementation on https://github.com/Liduska/pipenv-build-example, which is copy of repository I use with `requirements.txt` and `runtime.txt` removed. You can find original repository on https://github.com/Liduska/coffeeshop-netlify.

Thanks for the great product!