### PR TITLE
Install Google Bazel build tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     update-locale en_US.UTF-8 && \
     apt-key adv --fetch-keys https://packagecloud.io/github/git-lfs/gpgkey && \
     apt-add-repository -y -s 'deb https://packagecloud.io/github/git-lfs/ubuntu/ trusty main' && \
+    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
+    curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add - && \
     add-apt-repository -y ppa:ondrej/php && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
     add-apt-repository -y ppa:git-core/ppa && \
@@ -35,6 +37,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         apache2-utils \
         autoconf \
         automake \
+        bazel \
         bison \
         build-essential \
         bzr \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The specific patch versions included will depend on when the image was last buil
   * Any version installable via `binrc`.
 * Gutenburg - `GUTENBERG_VERSION`
   * Any version installable via `binrc`.
+* Bazel
 
 ## Testing locally
 


### PR DESCRIPTION
Google [Bazel] is a general-purpose polyglot build tool. Some projects frequently use it as a replacement for make or other build tools for generating static content, e.g. for generating API documentation from sources. It has rules available for building typescript code, Sass/CSS and more.

The build image already pulls in other build tools like CMake. Google Bazel is both general-purpose and fairly lightweight given that the main dependencies (Java) are already part of the image. In fact adding the `bazel` package induces no new dependencies apart from maybe `bash-completion`.

[Bazel]: https://bazel.build