### PR TITLE
install pandoc via deb provided by pandoc maintainer instead of distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ MAINTAINER Netlify
 ENV LANGUAGE en_US:en
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+ENV PANDOC_VERSION 2.2.1
 
 # language export needed for ondrej/php PPA https://github.com/oerdnj/deb.sury.org/issues/56
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -131,7 +132,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         nasm \
         openjdk-8-jdk \
         optipng \
-        pandoc \
         php5.6 \
         php5.6-xml \
         php5.6-mbstring \
@@ -169,6 +169,12 @@ RUN wget -nv https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4
     cd wkhtmltox && \
     cp -r ./ /usr/ && \
     wkhtmltopdf -V
+
+# install Pandoc (more recent version to what is provided in Ubuntu 14.04)
+RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-1-amd64.deb && \
+    dpkg -i pandoc-$PANDOC_VERSION-1-amd64.deb && \
+    rm pandoc-$PANDOC_VERSION-1-amd64.deb && \
+    pandoc -v
 
 ################################################################################
 #


### PR DESCRIPTION
Pandoc is an important tool for static site generators, and is the default markdown converter in all static sites from our organization. The Pandoc version that comes with Ubuntu 14.04 (1.12.2) and is currently used in `build-image` is too old to be really usable. This pull request installs the most recent version (2.2.1) via the `.deb` provided by the Pandoc maintainer instead, which is the easiest way to install a current Pandoc version in an Ubuntu environment.