### PR TITLE
Install the gd and sqlite3 PHP extensions to minimally support Drupal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,9 +136,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         php5.6 \
         php5.6-xml \
         php5.6-mbstring \
+        php5.6-gd \
+        php5.6-sqlite3 \
         php7.2 \
         php7.2-xml \
         php7.2-mbstring \
+        php7.2-gd \
+        php7.2-sqlite3 \
         pngcrush \
         python-setuptools \
         python2.7-dev \


### PR DESCRIPTION
👋 Hi there, I'm the maintainer of [Tome](https://tome.fyi/), an in-development static site generator built with Drupal 8.

This image has almost has everything Drupal needs to run, but is missing the "gd" extension which is required by [Drupal core's composer.json file](https://cgit.drupalcode.org/drupal/tree/core/composer.json#n10), and lacks any database driver.

Tome uses SQLite by default, which is already available as a binary in the image - I would just need the extension to get everything working.

I've verified that my [Netlify site built using Tome](https://github.com/drupal-tome/umami-netlify) works locally using the `./test-tools/test-build.sh` script (thanks for that, by the way!), so I think this is all that's needed to get Drupal minimally working on Netlify.

If you need any other information, please let me know! 🙇 