### PR TITLE
Make nix available in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -405,9 +405,10 @@ RUN mkdir -m 0755 /nix && chown buildbot /nix
 USER buildbot
 WORKDIR /tmp
 RUN curl -o install-nix https://nixos.org/nix/install && USER=buildbot sh ./install-nix && rm install-nix
+RUN mkdir -p /opt/buildhome/.nix/bin
 
-ENV PATH=/nix/var/nix/profiles/per-user/$USER/profile/bin:/nix/var/nix/profiles/per-user/$USER/profile/sbin:$PATH
-ENV NIX_PATH=/nix/var/nix/profiles/per-user/$USER/channels
+ENV PATH=/opt/buildhome/.nix/bin:$PATH
+ENV NIX_PATH=/nix/var/nix/profiles/per-user/buildbot/channels
 ENV NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -394,6 +394,22 @@ ENV GIMME_GO_VERSION "1.10"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme
 
+################################################################################
+#
+# Nix
+#
+################################################################################
+USER root
+RUN mkdir -m 0755 /nix && chown buildbot /nix
+
+USER buildbot
+WORKDIR /tmp
+RUN curl -o install-nix https://nixos.org/nix/install && USER=buildbot sh ./install-nix && rm install-nix
+
+ENV PATH=/nix/var/nix/profiles/per-user/$USER/profile/bin:/nix/var/nix/profiles/per-user/$USER/profile/sbin:$PATH
+ENV NIX_PATH=/nix/var/nix/profiles/per-user/$USER/channels
+ENV NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
 # Cleanup
 USER root
 


### PR DESCRIPTION
This makes [nix](https://nixos.org/nix/) available in the build image. It will allow users to use `nix-shell` or `nix-build` to build the websites.

I tested the image by building it and then executing `nix-shell` inside it:

```
docker run -ti <image> \
  nix-shell -p nodejs-10_x \
    --command "node -e 'console.log(process.version)'"
```

(here nix-shell is instructed to make node.js v10 available and then run `"node -e 'console.log(process.version)'"`).