### PR TITLE
Add erlang and elixir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         bzr \
         cmake \
         curl \
+        elixir \
         emacs25-nox \
         esl-erlang \
-        elixir \
         expect \
         fontconfig \
         fontconfig-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     echo 'LANGUAGE="en_US:en"' >> /etc/default/locale && \
     locale-gen en_US.UTF-8 && \
     update-locale en_US.UTF-8 && \
+    apt-key adv --fetch-keys https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
     apt-key adv --fetch-keys https://packagecloud.io/github/git-lfs/gpgkey && \
     apt-add-repository -y -s 'deb https://packagecloud.io/github/git-lfs/ubuntu/ trusty main' && \
     add-apt-repository -y ppa:ondrej/php && \
@@ -30,6 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     add-apt-repository -y ppa:rwky/graphicsmagick && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:kelleyk/emacs && \
+    apt-add-repository -y 'deb https://packages.erlang-solutions.com/ubuntu trusty contrib' && \
     apt-get -y update && \
     apt-get install -y --no-install-recommends \
         advancecomp \
@@ -42,6 +44,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         cmake \
         curl \
         emacs25-nox \
+        esl-erlang \
+        elixir \
         expect \
         fontconfig \
         fontconfig-config \
@@ -393,19 +397,6 @@ ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
 ENV GIMME_GO_VERSION "1.10"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme
-
-################################################################################
-#
-# Erlang+Elixir
-#
-################################################################################
-USER root
-# Erlang solutions repository
-RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-    dpkg -i erlang-solutions_1.0_all.deb
-RUN apt-get update
-RUN apt-get install -y esl-erlang elixir
-
 
 # Cleanup
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -394,6 +394,19 @@ ENV GIMME_GO_VERSION "1.10"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme
 
+################################################################################
+#
+# Erlang+Elixir
+#
+################################################################################
+USER root
+# Erlang solutions repository
+RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
+    dpkg -i erlang-solutions_1.0_all.deb
+RUN apt-get update
+RUN apt-get install -y esl-erlang elixir
+
+
 # Cleanup
 USER root
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The specific patch versions included will depend on when the image was last buil
   * 8 (default)
 * Emacs
   * 25 (default)
+* Erlang
+  * 21 (default)
+* Elixir
+  * 1.7 (default)
 
 ### Tools
 


### PR DESCRIPTION
Install erlang and [Elixir](https://elixir-lang.org/) in the build image. This will allow continuous deployments to use elixir (and erlang) to build websites.

I tested the image by building it and then executing `elixir --version` inside it:

```
❯ docker run -ti <image> elixir --version
Erlang/OTP 21 [erts-10.0] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe]

Elixir 1.7.0 (compiled with Erlang/OTP 20)
```