### PR TITLE
Add Hugo extended (>0.43)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -323,6 +323,7 @@ RUN binrc install spf13/hugo 0.17 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln 
     binrc install spf13/hugo 0.18 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.18 && \
     binrc install spf13/hugo 0.19 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.19 && \
     binrc install spf13/hugo 0.20 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.20 && \
+    binrc install spf13/hugo 0.48 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.48 && \
     ln -s /usr/local/bin/hugo_0.17 /usr/local/bin/hugo
 
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -326,6 +326,11 @@ RUN binrc install spf13/hugo 0.17 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln 
     binrc install spf13/hugo 0.48 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.48 && \
     ln -s /usr/local/bin/hugo_0.17 /usr/local/bin/hugo
 
+RUN mkdir /opt/buildhome/stdc++6 && \
+    wget -q -O libstdc++6.deb http://security.ubuntu.com/ubuntu/pool/main/g/gcc-5/libstdc++6_5.4.0-6ubuntu1~16.04.10_amd64.deb && \
+    dpkg -x libstdc++6.deb /opt/buildhome/stdc++6 && \
+    rm -fr libstdc++6.deb
+
 ################################################################################
 #
 # Clojure

--- a/Dockerfile
+++ b/Dockerfile
@@ -313,7 +313,7 @@ USER root
 #
 ################################################################################
 
-ENV BINRC_VERSION 0.2.5
+ENV BINRC_VERSION 0.2.6
 
 RUN mkdir /opt/binrc && cd /opt/binrc && \
     curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -441,9 +441,11 @@ install_dependencies() {
     then
       export PATH=$(dirname $hugoOut):$PATH
       if [ $(awk 'BEGIN {print ("'$HUGO_VERSION'" >= "'0.43'")}') -eq 1 ] ; then
-        grep "hugo=" /opt/buildhome/.bashrc || \
-          echo "alias hugo='LD_LIBRARY_PATH=/opt/buildhome/stdc++6/usr/lib/x86_64-linux-gnu hugo'" >> /opt/buildhome/.bashrc
+        export LD_LIBRARY_PATH=~/stdc++6/usr/lib/x86_64-linux-gnu
+        grep "hugo=" ~/.bashrc || \
+          echo "alias hugo='LD_LIBRARY_PATH=$LD_LIBRARY_PATH $hugoOut'" >> ~/.bashrc
       fi
+      echo "Hugo version set to $(hugo version)"
     else
       echo "Error during Hugo $HUGO_VERSION install: $hugoOut"
       exit 1

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -440,6 +440,10 @@ install_dependencies() {
     if [ $? -eq 0 ]
     then
       export PATH=$(dirname $hugoOut):$PATH
+      if [ $(awk 'BEGIN {print ("'$HUGO_VERSION'" >= "'0.43'")}') -eq 1 ] ; then
+        grep "hugo=" /opt/buildhome/.bashrc || \
+          echo "alias hugo='LD_LIBRARY_PATH=/opt/buildhome/stdc++6/usr/lib/x86_64-linux-gnu hugo'" >> /opt/buildhome/.bashrc
+      fi
     else
       echo "Error during Hugo $HUGO_VERSION install: $hugoOut"
       exit 1

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -440,10 +440,15 @@ install_dependencies() {
     if [ $? -eq 0 ]
     then
       export PATH=$(dirname $hugoOut):$PATH
-      if [ $(awk 'BEGIN {print ("'$HUGO_VERSION'" >= "'0.43'")}') -eq 1 ] ; then
-        export LD_LIBRARY_PATH=~/stdc++6/usr/lib/x86_64-linux-gnu
-        grep "hugo=" ~/.bashrc || \
-          echo "alias hugo='LD_LIBRARY_PATH=$LD_LIBRARY_PATH $hugoOut'" >> ~/.bashrc
+      if [ $(awk 'BEGIN {print ("'$HUGO_VERSION'" >= "'0.43'")}') -eq 1 ]
+      then
+        shopt -s expand_aliases
+        alias hugo='LD_LIBRARY_PATH=$HOME/stdc++6/usr/lib/x86_64-linux-gnu $hugoOut'
+        grep "hugo=" $NETLIFY_BUILD_BASE/.bashrc >/dev/null
+        if [ $? -eq 1 ]
+        then
+          echo "alias hugo='LD_LIBRARY_PATH=$HOME/stdc++6/usr/lib/x86_64-linux-gnu $hugoOut'" >> $NETLIFY_BUILD_BASE/.bashrc
+        fi
       fi
       echo "Hugo version set to $(hugo version)"
     else


### PR DESCRIPTION
Uncompress necessary files from one deb-package for using a CGO-extension compiled version of Hugo (>0.43).
See https://github.com/netlify/build-image/issues/183 and https://github.com/netlify/build-image/issues/182 

And set expand alias with LD_LIBRARY_PATH - only for hugo extended.
