### PR TITLE
Report lingering processes to the user

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -623,3 +623,32 @@ set_go_import_path() {
     cd $importPath
   fi
 }
+
+find_running_procs() {
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash
+}
+
+report_lingering_procs() {
+  procs=$(find_running_procs)
+  nprocs=$(expr $(echo "$procs" | wc -l) - 1)
+  if [[ $nprocs > 0 ]]; then
+    echo -e "${YELLOW}"
+    echo "** WARNING **"
+    echo "There are some lingering processes even after the build process finished: "
+    echo
+    echo "$procs"
+    echo
+    echo "Our builds do not kill your processes automatically, so please make sure"
+    echo "that nothing is running after your build finishes, or it will be marked as"
+    echo "failed since something is still running."
+    echo -e "${NC}"
+  fi
+}
+
+after_build_steps() {
+  echo "Caching artifacts"
+  cache_artifacts
+
+  # Find lingering processes after the build finished and report it to the user
+  report_lingering_procs
+}

--- a/run-build.sh
+++ b/run-build.sh
@@ -37,7 +37,6 @@ echo "Executing user command: $cmd"
 eval "$cmd"
 CODE=$?
 
-echo "Caching artifacts"
-cache_artifacts
+after_build_steps
 
 exit $CODE


### PR DESCRIPTION
Netlify builds will wait until all the processes finish. If they don't finish, the build will eventually timeout and will be marked as failed.

This code will detect and report any lingering process after the main build command finishes so the user can make sure they are terminated properly.