### PR TITLE
Update ruby gems bundle caching

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -312,7 +312,7 @@ install_dependencies() {
     if install_deps Gemfile.lock $RUBY_VERSION $NETLIFY_CACHE_DIR/gemfile-sha || [ ! -d .bundle ]
     then
       echo "Installing gem bundle"
-      if bundle install --path $NETLIFY_CACHE_DIR/bundle --binstubs=$NETLIFY_CACHE_DIR/binstubs ${BUNDLER_FLAGS:+"$BUNDLER_FLAGS"}
+      if bundle install --path .bundle --binstubs=$NETLIFY_CACHE_DIR/binstubs ${BUNDLER_FLAGS:+"$BUNDLER_FLAGS"}
       then
       export PATH=$NETLIFY_CACHE_DIR/binstubs:$PATH
         echo "Gem bundle installed"


### PR DESCRIPTION
There was a two-part typo for using the cached path when installing ruby gems.

In line 35 cache directory is defined as `$NETLIFY_CACHE_DIR/.bundle`, but in `--path` argument to `bundle install` it as passed as `$NETLIFY_CACHE_DIR/bundle` without the dot.

Additionally, because it's doing `restore_cwd_cache ".bundle"` before (and `cache_cwd_directory ".bundle"` at the end), that directory is moved to `$PWD` (and back after), so `$NETLIFY_CACHE_DIR/.bundle` is always empty when running `bundle install`, causing gems to be installed again.

This commit changes it so the `--path` argument to `bundle install` is simply `.bundle` in the current working directory so the existing caching mechanisms can be kept in place and bundler actually uses the gem cache.
There's no need to change the `--binstubs` argument because bundle will re-generate those even if gems are already installed (cached in this case).