### PR TITLE
Filter buildbot from lingering process message

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -625,7 +625,7 @@ set_go_import_path() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v [b]uildbot
 }
 
 report_lingering_procs() {


### PR DESCRIPTION
Followup to https://github.com/netlify/build-image/pull/202.  This should prevent the buildbot itself from triggering the lingering process message.

Closes https://github.com/netlify/build-image/issues/215