### PR TITLE
Fixed: Filter zombie processes

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -625,7 +625,7 @@ set_go_import_path() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot"
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct
 }
 
 report_lingering_procs() {


### PR DESCRIPTION
After getting some false positives on the process warning, this filters zombie processes which appear to be the culprit. 