### PR TITLE
Fix false positive process warning on non-0 exit code

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -625,7 +625,7 @@ set_go_import_path() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct | grep -v "[build]"
 }
 
 report_lingering_procs() {


### PR DESCRIPTION
We were getting the process warning without a lingering process on non-0 exit codes.  This filters out the false positive process that shows up.  

```
9:40:20 AM: 
9:40:20 AM: ** WARNING **
9:40:20 AM: There are some lingering processes even after the build process finished:
9:40:20 AM: USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
9:40:20 AM: buildbot  1163  0.0  0.0      4     4 ?        R    17:40   0:00 [build]
9:40:20 AM: Our builds do not kill your processes automatically, so please make sure
9:40:20 AM: that nothing is running after your build finishes, or it will be marked as
9:40:20 AM: failed since something is still running.
9:40:20 AM: 
9:40:20 AM: Error running command: Build script returned non-zero exit code: 255
9:40:20 AM: Failing build: Failed to build site
9:40:20 AM: failed during stage 'building site': Build script returned non-zero exit code: 255
9:40:20 AM: Finished processing build request in 13.133642892s
```