### PR TITLE
Add sha and tag docker tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} -t netlify/build:latest ."
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --squash -t netlify/build:squash ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} -t netlify/build:latest -t netlify/build:${env.GIT_COMMIT} -t netlify/build:${env.GIT_TAG} ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --squash -t netlify/build:squash -t netlify/build:${env.GIT_COMMIT}-squash -t netlify/build:${env.GIT_TAG}-squash ."
       }
     }
 
@@ -29,7 +29,11 @@ pipeline {
         script {
           docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
             docker.image('netlify/build:latest').push()
+            docker.image("netlify/build:${env.GIT_COMMIT}").push()
+            docker.image("netlify/build:${env.GIT_TAG}").push()
             docker.image('netlify/build:squash').push()
+            docker.image("netlify/build:${env.GIT_COMMIT}-squash").push()
+            docker.image("netlify/build:${env.GIT_TAG}-squash").push()
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,36 +4,66 @@ pipeline {
   stages {
     stage("Build") {
       when {
-        not { branch 'master' }
+        not { anyOf { branch 'master' ; branch 'staging'} }
       }
       steps {
         sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} ."
       }
     }
 
-    stage("Build Tagged") {
+    stage("Build Untagged") {
       when {
-        branch 'master'
+        anyOf { branch 'master' ; branch 'staging'}
+        not { buildingTag() }
       }
       steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} -t netlify/build:latest -t netlify/build:${env.GIT_COMMIT} -t netlify/build:${env.GIT_TAG} ."
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --squash -t netlify/build:squash -t netlify/build:${env.GIT_COMMIT}-squash -t netlify/build:${env.GIT_TAG}-squash ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} -t netlify/build:${env.BRANCH_NAME} -t netlify/build:${env.GIT_COMMIT} ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --squash -t netlify/build:${env.BRANCH_NAME}-squash -t netlify/build:${env.GIT_COMMIT}-squash ."
       }
     }
 
-    stage("Push") {
+    stage("Build Tagged") {
       when {
-        branch 'master'
+        anyOf { branch 'master' ; branch 'staging'}
+        buildingTag()
+      }
+      steps {
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} -t netlify/build:${env.BRANCH_NAME} -t netlify/build:${env.GIT_COMMIT} -t netlify/build:${env.GIT_TAG} ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --squash -t netlify/build:${env.BRANCH_NAME}-squash -t netlify/build:${env.GIT_COMMIT}-squash -t netlify/build:${env.GIT_TAG}-squash ."
+      }
+    }
+
+    stage("Push Tagged") {
+      when {
+        anyOf { branch 'master' ; branch 'staging'}
+        buildingTag()
       }
       steps {
         script {
           docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
-            docker.image('netlify/build:latest').push()
+            docker.image("netlify/build:${env.BRANCH_NAME}").push()
             docker.image("netlify/build:${env.GIT_COMMIT}").push()
             docker.image("netlify/build:${env.GIT_TAG}").push()
-            docker.image('netlify/build:squash').push()
+            docker.image("netlify/build:${env.BRANCH_NAME}-squash").push()
             docker.image("netlify/build:${env.GIT_COMMIT}-squash").push()
             docker.image("netlify/build:${env.GIT_TAG}-squash").push()
+          }
+        }
+      }
+    }
+
+    stage("Push Untagged") {
+      when {
+        anyOf { branch 'master' ; branch 'staging'}
+        buildingTag()
+      }
+      steps {
+        script {
+          docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
+            docker.image("netlify/build:${env.BRANCH_NAME}").push()
+            docker.image("netlify/build:${env.GIT_COMMIT}").push()
+            docker.image("netlify/build:${env.BRANCH_NAME}-squash").push()
+            docker.image("netlify/build:${env.GIT_COMMIT}-squash").push()
           }
         }
       }


### PR DESCRIPTION
In order to facilitate more fine-grained buildbot builds, we need a more fine-grained docker tagging strategy.  

This PR does the following: 

- Add COMMIT tags to our docker builds
- Adds COMMIT-squash tags to our docker builds
- Add TAG and TAG-squash docker tags when tagged
  