### PR TITLE
Fix untagged push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
     stage("Push Untagged") {
       when {
         anyOf { branch 'master' ; branch 'staging'}
-        buildingTag()
+        not { buildingTag() }
       }
       steps {
         script {


### PR DESCRIPTION
This fixes a minor mistake in the Jenkinsfile update we just merged.