### PR TITLE
Fix RVM gpg key retrieval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,6 +225,7 @@ RUN adduser --system --disabled-password --uid 2500 --quiet buildbot --home /opt
 ################################################################################
 
 USER buildbot
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail
 


### PR DESCRIPTION
When rebuilding dev I received the following warning:

```
Downloading https://github.com/rvm/rvm/releases/download/1.29.6/1.29.6.tar.gz.asc

gpg: Signature made Thu 13 Dec 2018 03:09:53 PM UTC using RSA key ID 39499BDB

gpg: Can't check signature: public key not found

Warning, RVM 1.26.0 introduces signed releases and automated check of signatures when GPG software found. Assuming you trust Michal Papis import the mpapis public key (downloading the signatures).



GPG signature verification failed for '/opt/buildhome/.rvm/archives/rvm-1.29.6.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.6/1.29.6.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:



    gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB



or if it fails:



    command curl -sSL https://rvm.io/mpapis.asc | gpg --import -

    command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -



the key can be compared with:



    https://rvm.io/mpapis.asc or https://keybase.io/mpapis

    https://rvm.io/pkuczynski.asc



NOTE: GPG version 2.1.17 have a bug which cause failures during fetching keys from remote server. Please downgrade or upgrade to newer version (if available) or use the second method described above.



The command '/bin/sh -c gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 &&     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail' returned a non-zero code: 2

script returned exit code 2
```

This attempts to remedy.