### PR TITLE
Fix Bundler version to 1.17.3 to prevent 2.0 being installed in ruby versions < 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,9 +237,9 @@ RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.2.9 && rvm use 2.2.9 && gem install bundler && \
-                  rvm install 2.3.6 && rvm use 2.3.6 && gem install bundler && \
-                  rvm install 2.4.3 && rvm use 2.4.3 && gem install bundler && \
+                  rvm install 2.2.9 && rvm use 2.2.9 && gem install bundler -v 1.17.3 && \
+                  rvm install 2.3.6 && rvm use 2.3.6 && gem install bundler -v 1.17.3 && \
+                  rvm install 2.4.3 && rvm use 2.4.3 && gem install bundler -v 1.17.3 && \
                   rvm use 2.3.6 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -279,7 +279,7 @@ install_dependencies() {
   
   if ! gem list -i "^bundler$" > /dev/null 2>&1
   then
-    if ! gem install bundler
+    if ! gem install bundler -v 1.17.3
     then
       echo "Error installing bundler"
       exit 1


### PR DESCRIPTION
[Bundler 2.0](https://rubygems.org/gems/bundler/versions/2.0.0) was released today (January 3rd, 2019). It requires rubygems 3.0.0 and drops support for ruby < 2.3. This is causing builds using custom ruby < 2.6 to fail.

In this change, we set the bundler version to 1.17.3—the current last one before 2.0.0—, so it keeps working with existing ruby setups.

Closes #245.