### PR TITLE
Partial revert of #197

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -314,7 +314,7 @@ USER root
 #
 ################################################################################
 
-ENV BINRC_VERSION 0.2.6
+ENV BINRC_VERSION 0.2.5
 
 RUN mkdir /opt/binrc && cd /opt/binrc && \
     curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \
@@ -324,7 +324,6 @@ RUN binrc install spf13/hugo 0.17 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln 
     binrc install spf13/hugo 0.18 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.18 && \
     binrc install spf13/hugo 0.19 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.19 && \
     binrc install spf13/hugo 0.20 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.20 && \
-    binrc install spf13/hugo 0.48 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.48 && \
     ln -s /usr/local/bin/hugo_0.17 /usr/local/bin/hugo
 
 RUN mkdir /opt/buildhome/stdc++6 && \

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -202,7 +202,7 @@ install_dependencies() {
   fi
 
   if nvm install $NODE_VERSION
-  then 
+  then
     NODE_VERSION=$(nvm current)
     # no echo needed because nvm does that for us
     export NODE_VERSION=$NODE_VERSION
@@ -276,7 +276,7 @@ install_dependencies() {
       exit 1
     fi
   fi
-  
+
   if ! gem list -i "^bundler$" > /dev/null 2>&1
   then
     if ! gem install bundler
@@ -440,17 +440,6 @@ install_dependencies() {
     if [ $? -eq 0 ]
     then
       export PATH=$(dirname $hugoOut):$PATH
-      if [ $(awk 'BEGIN {print ("'$HUGO_VERSION'" >= "'0.43'")}') -eq 1 ]
-      then
-        shopt -s expand_aliases
-        alias hugo='LD_LIBRARY_PATH=$HOME/stdc++6/usr/lib/x86_64-linux-gnu $hugoOut'
-        grep "hugo=" $NETLIFY_BUILD_BASE/.bashrc >/dev/null
-        if [ $? -eq 1 ]
-        then
-          echo "alias hugo='LD_LIBRARY_PATH=$HOME/stdc++6/usr/lib/x86_64-linux-gnu $hugoOut'" >> $NETLIFY_BUILD_BASE/.bashrc
-        fi
-      fi
-      echo "Hugo version set to $(hugo version)"
     else
       echo "Error during Hugo $HUGO_VERSION install: $hugoOut"
       exit 1


### PR DESCRIPTION
This reverts the binrc update, the Hugo alias hack, but keeps the shared libraries to help people use Hugo extended, if they provide their own binary.

This is not ideal, but its the minimum assistance we can provide on the Ubuntu 14 image.  

To use Hugo extended on the Ubuntu 14 image, download the version of Hugo that you want, then run it like this:

```console
LD_LIBRARY_PATH=$HOME/stdc++6/usr/lib/x86_64-linux-gnu ./hugo
```

Partially reverts #197