### PR TITLE
Install libenchant1c2a package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libcurl3 \
         libcurl3-gnutls \
         libcurl3-openssl-dev \
+        libenchant1c2a \
         libexif-dev \
         libffi-dev \
         libfontconfig1 \


### PR DESCRIPTION
This allows users to install the PyEnchant library, which depends on this C library 😄 

Without this patch, I get:

```
Collecting PyEnchant>=1.6.5 (from sphinxcontrib-spelling==4.2.0->-r requirements.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/9e/54/04d88a59efa33fefb88133ceb638cdf754319030c28aadc5a379d82140ed/pyenchant-2.0.0.tar.gz (64kB)
    100% |████████████████████████████████| 71kB 2.5MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-G9GRK4/PyEnchant/setup.py", line 212, in <module>
        import enchant
      File "enchant/__init__.py", line 92, in <module>
        from enchant import _enchant as _e
      File "enchant/_enchant.py", line 145, in <module>
        raise ImportError(msg)
    ImportError: The 'enchant' C library was not found. Please install it via your OS package manager, or use a pre-built binary wheel from PyPI.
```

Installing this package allows my documentation website (built using Sphinx) to build 😄 
