### PR TITLE
Update the latest stable versions of ruby and use 2.5.3 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         graphicsmagick \
         graphviz \
         gtk-doc-tools \
+        gnupg2 \
         imagemagick \
         jpegoptim \
         language-pack-ar \
@@ -232,7 +233,7 @@ RUN adduser --system --disabled-password --uid 2500 --quiet buildbot --home /opt
 
 ## TODO: Consider switching to rbenv or asdf-vm
 USER buildbot
-RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
+RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -230,17 +230,19 @@ RUN adduser --system --disabled-password --uid 2500 --quiet buildbot --home /opt
 #
 ################################################################################
 
+## TODO: Consider switching to rbenv or asdf-vm
 USER buildbot
 RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys D39DC0E3 && \
     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# Match this set latest Stable releases we can support on https://www.ruby-lang.org/en/downloads/
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.2.9 && rvm use 2.2.9 && gem install bundler && \
-                  rvm install 2.3.6 && rvm use 2.3.6 && gem install bundler && \
-                  rvm install 2.4.3 && rvm use 2.4.3 && gem install bundler && \
-                  rvm use 2.3.6 --default && rvm cleanup all"
+                  rvm install 2.6.1 && rvm use 2.6.1 && gem install bundler && \
+                  rvm install 2.5.3 && rvm use 2.5.3 && gem install bundler && \
+                  rvm install 2.4.5 && rvm use 2.4.5 && gem install bundler && \
+                  rvm use 2.6.1 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,7 @@ RUN adduser --system --disabled-password --uid 2500 --quiet buildbot --home /opt
 
 ## TODO: Consider switching to rbenv or asdf-vm
 USER buildbot
-RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ You can also use the image this generates to test locally if you're having build
 The specific patch versions included will depend on when the image was last built (except Ruby). It is highly suggested you depend only on minor versions, so that we can ensure the language has the latest updates (especially if security related).
 
 * Ruby - `RUBY_VERSION`, `.ruby-version`
-  * 2.2.9
-  * 2.3.6 (default)
-  * 2.4.3
+  * 2.6.1
+  * 2.5.3 (default)
+  * 2.4.5
   * Any version that `rvm` can install.
 * Node.js - `NODE_VERSION`, `.nvmrc`, `.node-version`
   * 4
@@ -90,7 +90,7 @@ docker pull netlify/build
 Prerequisites:
 1. This repository cloned locally
 2. The reposotory you would like to test also cloned locally
-3. Be sure to have a clean git status in the test repository (e.g. commit or stash).  
+3. Be sure to have a clean git status in the test repository (e.g. commit or stash).
 4. Ensure the test repository's branch is the inteneded one to be built
 
 Interactive Mode:

--- a/run-build.sh
+++ b/run-build.sh
@@ -19,7 +19,7 @@ fi
 cd $NETLIFY_REPO_DIR
 
 : ${NODE_VERSION="8"}
-: ${RUBY_VERSION="2.3.6"}
+: ${RUBY_VERSION="2.5.3"}
 : ${YARN_VERSION="1.3.2"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.10"}

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -17,7 +17,7 @@ set -e
 
 : ${NETLIFY_IMAGE="netlify/build"}
 : ${NODE_VERSION="8"}
-: ${RUBY_VERSION="2.3.6"}
+: ${RUBY_VERSION="2.5.3"}
 : ${YARN_VERSION="1.3.2"}
 : ${NPM_VERSION=""}
 : ${HUGO_VERSION="0.20"}


### PR DESCRIPTION
This updates the latest stable ruby's in trusty, and uses 2.5.3 by default.