### PR TITLE
Xenial: Update to hugo 0.54

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -309,12 +309,8 @@ RUN mkdir /opt/binrc && cd /opt/binrc && \
     curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \
     ln -s /opt/binrc/binrc_${BINRC_VERSION}_linux_amd64/binrc_${BINRC_VERSION}_linux_amd64 /usr/local/bin/binrc
 
-RUN binrc install spf13/hugo 0.17 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.17 && \
-    binrc install spf13/hugo 0.18 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.18 && \
-    binrc install spf13/hugo 0.19 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.19 && \
-    binrc install spf13/hugo 0.20 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.20 && \
-    binrc install gohugoio/hugo 0.52 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.52 && \
-    ln -s /usr/local/bin/hugo_0.17 /usr/local/bin/hugo
+RUN binrc install gohugoio/hugo 0.54.0 -c /opt/buildhome/.binrc | xargs -n 1 -I{} ln -s {} /usr/local/bin/hugo_0.54.0 && \
+    ln -s /usr/local/bin/hugo_0.54.0 /usr/local/bin/hugo
 
 ################################################################################
 #


### PR DESCRIPTION
Updates hugo to the latest version.  Other version can be download and cached at build time. 