### PR TITLE
Suffix binrc cache with version number

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -436,7 +436,7 @@ install_dependencies() {
   if [ -n "$HUGO_VERSION" ]
   then
     echo "Installing Hugo $HUGO_VERSION"
-    hugoOut=$(binrc install -c $NETLIFY_CACHE_DIR/.binrc hugo)
+    hugoOut=$(binrc install -c $NETLIFY_CACHE_DIR/.binrc-$BINRC_VERSION hugo)
     if [ $? -eq 0 ]
     then
       export PATH=$(dirname $hugoOut):$PATH
@@ -451,7 +451,7 @@ install_dependencies() {
   if [ -n "$GUTENBERG_VERSION" ]
   then
     echo "Installing Gutenberg $GUTENBERG_VERSION"
-    gutenbergOut=$(binrc install -c $NETLIFY_CACHE_DIR/.binrc gutenberg)
+    gutenbergOut=$(binrc install -c $NETLIFY_CACHE_DIR/.binrc-$BINRC_VERSION gutenberg)
     if [ $? -eq 0 ]
     then
       export PATH=$(dirname $gutenbergOut):$PATH


### PR DESCRIPTION
This is to prevent caching overlap with other versions of binrc