### PR TITLE
Fix heading level in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Here is an example that sets `NODE_VERSION` and `NODE_ENV` before running a buil
 export NODE_VERSION=8 NODE_ENV=production ; build npm run build
 ```
 
-## Testing locally with cache
+### Testing locally with cache
 
 If you'd like to run a debugging build using our caching mechanisms, with verbose shell output, you can replace steps 2 and 3 above with the following command:
 


### PR DESCRIPTION
I meant for the "Testing with cache" section to be an h3 under "Running locally". 😛 