### PR TITLE
Add Clojure CLI tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         python3-dev \
         python3.7 \
         python3.7-dev \
+        rlwrap \
         rsync \
         software-properties-common \
         sqlite3 \
@@ -369,6 +370,8 @@ RUN mkdir /opt/boot-clj && cd /opt/boot-clj && \
     curl -sL https://github.com/boot-clj/boot-bin/releases/download/2.5.2/boot.sh > boot && \
     chmod +x boot && \
     ln -s /opt/boot-clj/boot /usr/local/bin/boot
+
+RUN curl -sL https://download.clojure.org/install/linux-install-1.10.1.492.sh | bash
 
 USER buildbot
 


### PR DESCRIPTION
Many people using Clojure are migrating away from Leiningen and Boot and using the newer [Clojure CLI](https://clojure.org/guides/deps_and_cli) to specify dependencies and build scripts.

This commit adds support for the Clojure CLI tools to the Netlify build image, approximately following [the Linux installation instructions](https://clojure.org/guides/getting_started#_installation_on_linux).

I also added the apt `rlwrap` package because the `clj` program requires it. The `clojure` program does not, but I think many people are calling `clj` instead of `clojure` out of habit.

There have been two prior pull requests attempting to add these tools ([1](https://github.com/netlify/build-image/pull/247) [2](https://github.com/netlify/build-image/pull/279)). I think both failed to successfully build the docker image. I have verified that the Dockerfile in this commit does successfully build an image, and I have used that image to successfully build [a project of mine](https://gitlab.com/unc-app-lab/website) that uses the Clojure CLI tools, so I'm reasonably confident that this works.