### PR TITLE
Add pngquant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         php7.2-curl \
         php7.2-zip \
         pngcrush \
+        pngquant \
         python-setuptools \
         python \
         python-dev \

--- a/included_software.md
+++ b/included_software.md
@@ -65,4 +65,5 @@ The specific patch versions included will depend on when the image was last buil
 * [ImageMagick](https://www.imagemagick.org) - 6.7.7
 * [GNU Make](https://www.gnu.org/software/make/) - 3.81
 * OptiPNG - 0.6.4
+* [pngquant](https://pngquant.org/) - 2.5.0
 * [Doxygen](http://www.doxygen.org) - 1.8.6


### PR DESCRIPTION
This PR makes [pngquant](https://pngquant.org/) available in the container, that can potentially produce smaller optimized PNG images than what's available in the image right now.