### PR TITLE
Install Bower with Appropriate Package Manager

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -379,7 +379,14 @@ install_dependencies() {
   then
     if ! [ $(which bower) ]
     then
-      npm install bower
+      if [ -f yarn.lock ]
+      then
+        echo "Installing bower with Yarn"
+        yarn add bower
+      else
+        echo "Installing bower with NPM"
+        npm install bower
+      fi
       export PATH=$(npm bin):$PATH
     fi
     restore_cwd_cache bower_components "bower components"


### PR DESCRIPTION
## Problem

My project uses Yarn to manage dependencies. My project also contains a `bower.json` file so that users can install it with Bower. 

When Netlify builds my project, I was getting build errors that I couldn't reproduce locally. I could see `npm` notices, even though all my deps are installed with Yarn. 

In `run-build-functions`, Bower is installed via `npm install bower`. This impacted the `node_modules` in my project, and generated a `package-lock.json`. After this command runs, my build command fails. However, `yarn add bower` works fine and my build succeeds.

#### summary

- bower is installed with `npm` even if your project uses `yarn`
- this generates a `package-lock.json` & may modify previously installed `node_modules`
- may break builds with 'fragile' dependencies 

## Solution

Check if `yarn.lock` exists:
- if yes, install bower via `yarn add bower`
- if no, install bower via `npm install bower` 


My current work around is to prepend my build command with:

```
rm -rf node_modules && rm -rf package-lock.json && yarn
```

Not a great workaround as it increases build time, but gets the build passing again.