### PR TITLE
Add Zip-it-and-ship-it ENV var to trusty image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -324,6 +324,13 @@ RUN mkdir /opt/binrc && cd /opt/binrc && \
     curl -sL https://github.com/netlify/binrc/releases/download/v${BINRC_VERSION}/binrc_${BINRC_VERSION}_Linux-64bit.tar.gz | tar zxvf - && \
     ln -s /opt/binrc/binrc_${BINRC_VERSION}_linux_amd64/binrc_${BINRC_VERSION}_linux_amd64 /usr/local/bin/binrc
 
+# Create a place for binrc to link/persist installs to the PATH
+USER buildbot
+RUN mkdir -p /opt/buildhome/.binrc/bin
+ENV PATH "/opt/buildhome/.binrc/bin:$PATH"
+
+USER root
+
 ################################################################################
 #
 # Hugo

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -461,6 +461,24 @@ install_dependencies() {
     fi
   fi
 
+  # zip-it-and-ship-it
+  if [ -n "$ZISI_VERSION" ]
+  then
+    echo "Installing Zip-it-and-ship-it $ZISI_VERSION"
+
+    zisiOut=$(binrc install -c $NETLIFY_BUILD_BASE/.binrc netlify/zip-it-and-ship-it $ZISI_VERSION)
+    if [ $? -eq 0 ]
+    then
+      echo $zisiOut
+      ln -s $zisiOut /opt/buildhome/.binrc/bin/zip-it-and-ship-it_${ZISI_VERSION}
+      ln -s /opt/buildhome/.binrc/bin/zip-it-and-ship-it_${ZISI_VERSION} /opt/buildhome/.binrc/bin/zip-it-and-ship-it
+      zip-it-and-ship-it --version
+    else
+      echo "Error during Zip-it-and-ship-it $ZISI_VERSION install: $zisiOut"
+      exit 1
+    fi
+  fi
+
   # Cask
   if [ -f Cask ]
   then

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -469,10 +469,9 @@ install_dependencies() {
     zisiOut=$(binrc install -c $NETLIFY_BUILD_BASE/.binrc netlify/zip-it-and-ship-it $ZISI_VERSION)
     if [ $? -eq 0 ]
     then
-      echo $zisiOut
       ln -s $zisiOut /opt/buildhome/.binrc/bin/zip-it-and-ship-it_${ZISI_VERSION}
       ln -s /opt/buildhome/.binrc/bin/zip-it-and-ship-it_${ZISI_VERSION} /opt/buildhome/.binrc/bin/zip-it-and-ship-it
-      zip-it-and-ship-it --version
+      echo zip-it-and-ship-it version: $(zip-it-and-ship-it --version)
     else
       echo "Error during Zip-it-and-ship-it $ZISI_VERSION install: $zisiOut"
       exit 1


### PR DESCRIPTION
Adds an env var to swap out the ZISI binary on site build prep.