### PR TITLE
Set wapm in the path, even when there is no wapm config files

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -532,11 +532,11 @@ install_dependencies() {
   fi
 
   # WAPM version
+  source $HOME/.wasmer/wasmer.sh
   if [ -f wapm.toml ] || [ -f wapm.lock ]
   then
     restore_home_cache ".wasmer/cache" "wasmer cache"
     restore_cwd_cache "wapm_packages" "wapm packages"
-    source $HOME/.wasmer/wasmer.sh
     wapm install
     if [ $? -eq 0 ]
     then


### PR DESCRIPTION
So you can install individual modules without having to configure them