### PR TITLE
Add Prep functions build function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 
     stage("Push Squash Images") {
       when {
-        anyOf { buildingTag()}
+        anyOf { buildingTag() }
       }
       steps {
         script {

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -483,7 +483,7 @@ install_dependencies() {
       exit 1
     fi
   fi
-  
+
   # zip-it-and-ship-it
   if [ -n "$ZISI_VERSION" ]
   then
@@ -684,6 +684,39 @@ set_go_import_path() {
   fi
 }
 
+prep_functions() {
+  local functionsDir=$1
+  local zisiTempDir=$2
+
+  if [[ -z "$functionsDir" ]]; then
+    echo "Skipping functions preparation step: no functions directory set"
+    return 0
+  else
+    echo Function Dir: $functionsDir
+  fi
+
+  if [[ ! -d "$functionsDir" ]]; then
+    echo "Skipping functions preparation step: $functionsDir not found"
+    return 0
+  fi
+
+  if [[ -z "$zisiTempDir" ]]; then
+    echo "Skipping functions preparation step: no temp directory set"
+  else
+    echo TempDir: $zisiTempDir
+  fi
+  # ZISI will create this foler if it doesn't exist, we don't need to check for it
+
+  echo Prepping functions with zip-it-and-ship-it $(zip-it-and-ship-it --version)
+
+  if zip-it-and-ship-it $functionsDir $zisiTempDir; then
+    echo "Prepping functions complete"
+  else
+    echo "Error prepping functions"
+    exit 1
+  fi
+}
+
 find_running_procs() {
   ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct | grep -v "[build]"
 }
@@ -703,9 +736,4 @@ report_lingering_procs() {
     echo "failed since something is still running."
     echo -e "${NC}"
   fi
-}
-
-after_build_steps() {
-  # Find lingering processes after the build finished and report it to the user
-  report_lingering_procs
 }

--- a/run-build.sh
+++ b/run-build.sh
@@ -37,6 +37,4 @@ echo "Executing user command: $cmd"
 eval "$cmd"
 CODE=$?
 
-after_build_steps
-
 exit $CODE


### PR DESCRIPTION
Adds a prep functions step to run_build functions, which we can run to prepare functions with zip-it-and-ship-it from inside the build environment, enabling fancier build and dependency installs. 

This is an alternative implementation from having separate buildbot stages, so that we can improve our bundling experience with the users build environment. 