### PR TITLE
Update docker pull command instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Emulating Netlify's buildbot on your local machine requires the following:
 Open your Docker terminal, and run the following command to pull the default image:
 
 ```
+docker pull netlify/build:latest
+or
 docker pull netlify/build:xenial
 or
 docker pull netlify/build:v3.0.2 # replace the version with a git tag of the specific version you want to test


### PR DESCRIPTION
Update the `docker pull` command instructions to suggest `build:latest`, because that's what the `start-image` script will attempt to grab when run from `master`. This avoids downloading `xenial` only to have the `start-image` script re-download `latest`.

Alternatively, it seems like perhaps all of Step 1 could be removed as the `start-image` script will fetch the image if it isn't available.