### PR TITLE
Add Rust support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -453,6 +453,14 @@ ENV DOTNET_ROOT "/opt/buildhome/.dotnet"
 RUN dotnet new
 WORKDIR /
 
+################################################################################
+#
+# Rust toolchain
+#
+################################################################################
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH "$PATH:/opt/buildhome/.cargo/bin"
+
 # Cleanup
 USER root
 

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -52,6 +52,7 @@ mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gopath
 mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gocache
 mkdir -p $NETLIFY_CACHE_DIR/.wasmer/cache
 mkdir -p $NETLIFY_CACHE_DIR/.cargo/registry
+mkdir -p $NETLIFY_CACHE_DIR/repo/target
 
 : ${YARN_FLAGS=""}
 : ${NPM_FLAGS=""}
@@ -576,6 +577,7 @@ install_dependencies() {
   if [ -f Cargo.toml ] || [ -f Cargo.lock ]
   then
     restore_home_cache ".cargo/registry" "rust deps"
+    restore_home_cache "repo/target" "rust compile output"
     source $HOME/.cargo/env
     cargo build --release
     if [ $? -eq 0 ]
@@ -615,7 +617,8 @@ cache_artifacts() {
   cache_home_directory ".boot" "boot dependencies"
   cache_home_directory ".composer" "composer dependencies"
   cache_home_directory ".wasmer/cache", "wasmer cache"
-  cache_home_directory ".cargo/registry" "rust toolchain and deps"
+  cache_home_directory ".cargo/registry" "rust deps"
+  cache_home_directory "repo/target" "rust compile output"
 
   # Don't follow the Go import path or we'll store
   # the origin repo twice.

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -577,7 +577,6 @@ install_dependencies() {
   then
     restore_home_cache ".cargo/registry" "rust deps"
     source $HOME/.cargo/env
-    cargo update
     cargo build --release
     if [ $? -eq 0 ]
     then

--- a/run-build.sh
+++ b/run-build.sh
@@ -37,4 +37,6 @@ echo "Executing user command: $cmd"
 eval "$cmd"
 CODE=$?
 
+cache_artifacts
+
 exit $CODE


### PR DESCRIPTION
Stable toolchain only for the time being. Caching of `target/` dir is conditional on this directory actually being ignored in the repository. I've tested both cases with a [dummy rust project](https://github.com/yacoob/aoc-2018) and it seems to be working.

Note: this PR also adds `cache_artifacts` to `run-build.sh`, as it seems to have been removed recently, and without it caching doesn't happen at all (bug [here](https://github.com/netlify/build-image/issues/318)). Given the caching still happens in prod, maybe this simply got moved somewhere outside of this repository - if that's the case, feel free to remove this file from the PR.