### PR TITLE
Support specifying docker image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ docker pull netlify/build:v3.0.2 # replace the version with a git tag of the spe
 
 Still in your Docker terminal, change directories into your local clone of this build-image repository.
 
-If you pulled an alternate image in Step 1, check out the corresponding branch in this repository.
-
 Run the following command to start the interactive shell within the container:
 
 ```
 ./test-tools/start-image.sh path/to/site/repo
 ```
+
+> If you pulled an alternate image in Step 1, set the `NETLIFY_IMAGE` variable with your command:
+> `NETLIFY_IMAGE=netlify/build:VERSION script/start-image.sh path/to/site/repo`
 
 If you receive a `command not found` message, make sure you are in the baase of the build-image repository.
 

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+: ${NETLIFY_IMAGE="netlify/build"}
+
 BASE_PATH=$(pwd)
 REPO_PATH=$(cd $1 && pwd)
 
@@ -14,4 +16,4 @@ docker run --rm -t -i \
 	-v ${REPO_PATH}:/opt/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
-	netlify/build /bin/bash
+	$NETLIFY_IMAGE /bin/bash


### PR DESCRIPTION
Support the `NETLIFY_IMAGE` environment variable when running `./test-tools/start-image.sh` as per `./test-tools/start-image.sh`. This allows better control of local debugging of builds.