### PR TITLE
Update run-build-functions.sh

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -590,6 +590,7 @@ cache_artifacts() {
   cache_cwd_directory "node_modules" "node modules"
   cache_cwd_directory ".venv" "python virtualenv"
   cache_cwd_directory "wapm_packages", "wapm packages"
+  cache_cwd_directory ".cache" "gatsby cache"
 
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache" "pip cache"


### PR DESCRIPTION
Gatsby stores it's build cache in the `.cache` folder. This PR might need some extra work to make sure the build is running with a Gatsby environment but if we know that there's no reason not to store the .cache directory. Gatsby handles invalidation. This would save Netlify from doing CPU intensive tasks repeatedly for every build like cropping images via gatsby-image. Might be able to borrow some logic from: https://github.com/netlify/build-image/compare/xenial...yacoob:rust?expand=1