### PR TITLE
Add GSL lib to speed LSI with Jekyll

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libgif-dev \
         libglib2.0-dev \
         libgmp3-dev \
+        libgsl2 \
+        libgsl-dev \
         libgtk-3-0 \
         libgtk2.0-0 \
         libicu-dev \


### PR DESCRIPTION
TL;DR: GSL lib speed up the Latent Semantic Indexer (LSI) [implementation in Jekyll](https://github.com/jekyll/classifier-reborn) by [a huge factor](https://footle.org/2014/11/06/speeding-up-jekylls-lsi/).

---
I've setup a project on Netlify but the deploy failed because my jekyll blog use GSL to speed up LSI. And the [gem](https://rubygems.org/gems/gsl/versions/1.16.0.6) require a library to be installed in the system to works.
I've open a ticket on your support (8206) and they told me to open a PR to add the library.

Here is the deploy log:

```
10:45:37 AM: Fetching gem metadata from https://rubygems.org/
10:45:37 AM: .
10:45:37 AM: .
10:45:37 AM: .
10:45:37 AM: .
10:45:38 AM: .
10:45:38 AM: .
10:45:38 AM: .
10:45:38 AM: .
10:45:38 AM: .
10:45:38 AM: .
10:45:38 AM: Fetching concurrent-ruby 1.1.5
10:45:39 AM: Installing concurrent-ruby 1.1.5
[...]
10:46:13 AM: Fetching gsl 2.1.0.3
10:46:14 AM: Installing gsl 2.1.0.3 with native extensions
10:46:14 AM: Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
10:46:14 AM: current directory:
10:46:14 AM: /opt/build/cache/bundle/ruby/2.6.0/gems/gsl-2.1.0.3/ext/gsl_native
10:46:14 AM: /opt/buildhome/.rvm/rubies/ruby-2.6.2/bin/ruby -I
10:46:14 AM: /opt/buildhome/.rvm/rubies/ruby-2.6.2/lib/ruby/2.6.0 -r
10:46:14 AM: ./siteconf20190909-1296-nxe5e3.rb extconf.rb
10:46:14 AM: failed during stage 'building site': Build script returned non-zero exit code: 1
10:46:14 AM: *** ERROR: missing required library to compile this module: No such file or
10:46:14 AM: directory - gsl-config
10:46:14 AM: *** extconf.rb failed ***
10:46:14 AM: Could not create Makefile due to some reason, probably lack of necessary
10:46:14 AM: libraries and/or headers.  Check the mkmf.log file for more details.  You may
10:46:14 AM: need configuration options.
10:46:14 AM: Provided configuration options:
10:46:14 AM: 	--with-opt-dir
10:46:14 AM: 	--without-opt-dir
10:46:14 AM: 	--with-opt-include
10:46:14 AM: 	--without-opt-include=${opt-dir}/include
10:46:14 AM: 	--with-opt-lib
```

After applying my changes locally and testing, the command works:

```
~/Sites/github/netlify-build-image$ ./test-tools/test-build.sh ../blog/ 'jekyll build'
Using temp dir: tmp/tmp.Jr0pSo6eQy
Clonage dans 'tmp/tmp.Jr0pSo6eQy/repo'...
fait.
Installing dependencies
v10.16.3 is already installed.
Now using node v10.16.3 (npm v6.9.0)
Attempting ruby version 2.6.2, read from environment
Using ruby version 2.6.2
Using PHP version 5.6
Started restoring cached ruby gems
Finished restoring cached ruby gems
Installing gem bundle
Warning: the running version of Bundler (1.17.2) is older than the version that created the lockfile (1.17.3). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/..........
Fetching concurrent-ruby 1.1.5
Installing concurrent-ruby 1.1.5
[...]
Fetching gsl 2.1.0.3
Installing gsl 2.1.0.3 with native extensions
Fetching rb-fsevent 0.10.3
Installing rb-fsevent 0.10.3
[...]
```