### PR TITLE
Add missing preinstalled Ruby versions

### DIFF
--- a/included_software.md
+++ b/included_software.md
@@ -12,6 +12,9 @@ The specific patch versions included will depend on when the image was last buil
   * 2.6.2 (default)
   * 2.5.4
   * 2.4.5
+  * 2.4.3
+  * 2.3.6
+  * 2.2.9
   * Any version that `rvm` can install.
 * Node.js - `NODE_VERSION`, `.nvmrc`, `.node-version`
   * 10 (default)


### PR DESCRIPTION
Updates the included software list for the **Trusty** branch to include all preinstalled Ruby versions, as installed in the Trusty [Dockerfile](https://github.com/netlify/build-image/blob/trusty/Dockerfile#L243) and shown in deploy logs for sites using the Trusty image:
![included-versions](https://user-images.githubusercontent.com/6111186/65626989-42722f00-df83-11e9-9c9d-63095be944c8.png)
