### PR TITLE
Update libvips to 8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,11 +211,11 @@ RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-
 
 WORKDIR /tmp
 
-# this actually builds v8.6.2
+# this actually builds v8.8.3
 RUN \
-  curl -sLo vips-8.6.2.tar.gz https://github.com/jcupitt/libvips/archive/v8.6.2.tar.gz && \
-  tar xvf vips-8.6.2.tar.gz && \
-  cd libvips-8.6.2 && \
+  curl -sLo vips-8.8.3.tar.gz https://github.com/libvips/libvips/releases/download/v8.8.3/vips-8.8.3.tar.gz && \
+  tar xvf vips-8.8.3.tar.gz && \
+  cd vips-8.8.3 && \
   ./autogen.sh && \
   ./configure --enable-debug=no --enable-docs=no --without-python --without-orc --without-fftw --without-gsf $1 && \
   make && \


### PR DESCRIPTION
I am having this error using sharp: 
<img width="1132" alt="Screen Shot 2019-10-05 at 7 20 03 AM" src="https://user-images.githubusercontent.com/3483656/66254405-e312dc80-e743-11e9-97b7-422fac69e267.png">

This prevents any deploy with the latest stable version of gatsby or any other library relying on the latest version of sharp