### PR TITLE
Pin bundler version so builds pinning it to old version keep working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 
 # Match this set latest Stable releases we can support on https://www.ruby-lang.org/en/downloads/
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.6.2 && rvm use 2.6.2 && gem install bundler && \
+                  rvm install 2.6.2 && rvm use 2.6.2 && gem install bundler:2.0.1 && \
                   rvm use 2.6.2 --default && rvm cleanup all"
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -284,7 +284,7 @@ install_dependencies() {
 
   if ! gem list -i "^bundler$" > /dev/null 2>&1
   then
-    if ! gem install bundler
+    if ! gem install bundler:2.0.1
     then
       echo "Error installing bundler"
       exit 1


### PR DESCRIPTION
Pinning bundler to 2.0.1 was recommended as a workaround to not being able to install bundles created with the latest version of bundler. That was caused by the build-image only using a single
version of bundler and then going un-updated for a long time. This resulted in a lot of customers using Gemfile.locks with an old version of bundler (2.0.1) listed as BUNDLED_WITH. When the build-image
underlying the buildbot was updated and deployed, all these builds started failing because the build-image had the latest version of bundler (2.0.2).

See https://github.com/netlify/build-image/issues/328 and https://github.com/netlify/build-image/issues/331.

See also https://github.com/netlify/build-image/issues/296, which is the long-term solution to this issue.