### PR TITLE
Fix test-tools/test-build.sh

### DIFF
--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-# Usage: script/test-build.sh PATH_TO_GIT_REPO BUILD_COMMAND
+# Usage: test-tools/test-build.sh PATH_TO_GIT_REPO BUILD_COMMAND
 #
 # Example with clean git clone:
-# 	./test-build.sh ../netlify-cms 'npm run build'
+#   test-tools/test-build.sh ../netlify-cms 'npm run build'
 #
 # Example with previous cached build:
-#	T=/tmp/cache script/test-build.sh ../netlify-cms 'npm run build'
+#   T=/tmp/cache script/test-build.sh ../netlify-cms 'npm run build'
+
+set -e
 
 if [ $NETLIFY_VERBOSE ]
 then
   set -x
 fi
-
-set -e
 
 : ${NETLIFY_IMAGE="netlify/build"}
 : ${NODE_VERSION="10"}
@@ -24,7 +24,8 @@ set -e
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
 
-REPO_URL=$1
+BASE_PATH=$(pwd)
+REPO_PATH="$(cd $1 && pwd)"
 
 mkdir -p tmp
 if [ $(uname -s) == "Darwin" ]; then
@@ -33,33 +34,27 @@ else
   : ${T=`mktemp -d -p tmp`}
 fi
 
-echo "Using temp dir: $T"
+echo "Using temp cache dir: $T/cache"
 chmod +w $T
-mkdir -p $T/scripts
 mkdir -p $T/cache
 chmod a+w $T/cache
 
-cp run-build* $T/scripts
-chmod +x $T/scripts/*
-
-rm -rf $T/repo
-git clone $REPO_URL $T/repo
-
-SCRIPT="/opt/buildhome/scripts/run-build.sh $2"
+SCRIPT="/usr/local/bin/build $2"
 
 docker run --rm \
-	-e "NODE_VERSION=$NODE_VERSION" \
-	-e "RUBY_VERSION=$RUBY_VERSION" \
-	-e "YARN_VERSION=$YARN_VERSION" \
-	-e "NPM_VERSION=$NPM_VERSION" \
-	-e "HUGO_VERSION=$HUGO_VERSION" \
-	-e "PHP_VERSION=$PHP_VERSION" \
-	-e "NETLIFY_VERBOSE=$NETLIFY_VERBOSE" \
-	-e "GO_VERSION=$GO_VERSION" \
-	-e "GO_IMPORT_PATH=$GO_IMPORT_PATH" \
-	-v $PWD/$T/scripts:/opt/buildhome/scripts \
-	-v $PWD/$T/repo:/opt/buildhome/repo \
-	-v $PWD/$T/cache:/opt/buildhome/cache \
-	-w /opt/build \
-	-it \
-	$NETLIFY_IMAGE $SCRIPT
+       -e NODE_VERSION \
+       -e RUBY_VERSION \
+       -e YARN_VERSION \
+       -e NPM_VERSION \
+       -e HUGO_VERSION \
+       -e PHP_VERSION \
+       -e NETLIFY_VERBOSE \
+       -e GO_VERSION \
+       -e GO_IMPORT_PATH \
+       -v "${REPO_PATH}:/opt/repo" \
+       -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
+       -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \
+       -v $PWD/$T/cache:/opt/buildhome/cache \
+       -w /opt/build \
+       -it \
+       $NETLIFY_IMAGE $SCRIPT


### PR DESCRIPTION
This script has either been broken for quite some time or never worked in the first place. Fixing it allows testing builds non-interactively. I based the changes to this script on the structure of `test-tools/start-image.sh`, which has been working the whole time.

If we decide not to merge this, we should remove `test-tools/test-build.sh` so it doesn't mislead people into thinking their build is broken when it's actually the test script.