### PR TITLE
start-image.sh should launch correct image on trusty

### DIFF
--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -14,4 +14,4 @@ docker run --rm -t -i \
 	-v ${REPO_PATH}:/opt/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
-	netlify/build /bin/bash
+	netlify/build:trusty /bin/bash


### PR DESCRIPTION
Followed the readme instructions for running but noticed that it was still launching `:latest`.