### PR TITLE
Swift Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -475,11 +475,11 @@ RUN dotnet new
 #
 ################################################################################
 USER buildbot
-ENV SWIFTENV_SWIFT_VERSION 5.1.3
+ENV NETLIFY_BUILD_SWIFT_VERSION 5.1.3
 ENV SWIFTENV_ROOT "/opt/buildhome/.swiftenv"
 RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
 ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
-RUN swiftenv install ${SWIFTENV_SWIFT_VERSION}
+RUN swiftenv install ${NETLIFY_BUILD_SWIFT_VERSION}
 RUN swift --version
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -479,14 +479,17 @@ RUN dotnet new
 WORKDIR /tmp
 RUN mkdir -p /opt/buildhome/.swift
 ENV SWIFT_BIN_URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
+RUN wget -q -O - https://swift.org/keys/all-keys.asc | \
+    gpg --import -
 RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig" -o swift.tar.gz.sig \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
     && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \
     && rm swift.tar.gz.sig swift.tar.gz
 ENV PATH "$PATH:/opt/buildhome/.swift/usr/bin"
 ENV SWIFT_ROOT "/opt/buildhome/.swift"
-#populate local package cache
 RUN swift --version
+
 WORKDIR /
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -480,7 +480,6 @@ WORKDIR /tmp
 RUN mkdir -p /opt/buildhome/.swift
 ENV SWIFT_BIN_URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
 RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig" -o swift.tar.gz.sig \
-    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
     && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \
     && rm swift.tar.gz.sig swift.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -480,7 +480,7 @@ RUN mkdir -p /opt/buildhome/.swift
 ENV SWIFT_BIN_URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
 RUN wget -q -O - https://swift.org/keys/all-keys.asc | \
     gpg --import -
-RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig" -o swift.tar.gz.sig \
+RUN curl -fsL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig" -o swift.tar.gz.sig \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
     && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     update-locale en_US.UTF-8 && \
     apt-key adv --fetch-keys https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
     apt-key adv --fetch-keys https://packagecloud.io/github/git-lfs/gpgkey && \
-    apt-key adv --fetch-keys https://swift.org/keys/all-keys.asc && \
     apt-add-repository -y -s 'deb https://packagecloud.io/github/git-lfs/ubuntu/ xenial main' && \
     add-apt-repository -y ppa:ondrej/php && \
     add-apt-repository -y ppa:openjdk-r/ppa && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -476,10 +476,11 @@ RUN dotnet new
 #
 ################################################################################
 USER buildbot
-ENV SWIFTENV_ROOT="/opt/buildhome/.swiftenv"
+ENV SWIFTENV_SWIFT_VERSION 5.1.3
+ENV SWIFTENV_ROOT "/opt/buildhome/.swiftenv"
 RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
 ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
-RUN swiftenv install 5.1.3
+RUN swiftenv install ${SWIFTENV_SWIFT_VERSION}
 RUN swift --version
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -478,7 +478,7 @@ RUN dotnet new
 USER buildbot
 ENV SWIFTENV_ROOT="/opt/buildhome/.swiftenv"
 RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
-ENV PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
+ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 RUN swiftenv install 5.1.3
 RUN swift --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         bison \
         build-essential \
         bzr \
-        clang \
         cmake \
         curl \
         doxygen \

--- a/Dockerfile
+++ b/Dockerfile
@@ -479,7 +479,7 @@ RUN dotnet new
 WORKDIR /tmp
 RUN mkdir -p /opt/buildhome/.swift
 ENV SWIFT_BIN_URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
-RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig"" -o swift.tar.gz.sig \
+RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig" -o swift.tar.gz.sig \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
     && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     update-locale en_US.UTF-8 && \
     apt-key adv --fetch-keys https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
     apt-key adv --fetch-keys https://packagecloud.io/github/git-lfs/gpgkey && \
+    apt-key adv --fetch-keys https://swift.org/keys/all-keys.asc && \
     apt-add-repository -y -s 'deb https://packagecloud.io/github/git-lfs/ubuntu/ xenial main' && \
     add-apt-repository -y ppa:ondrej/php && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
@@ -41,6 +42,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         bison \
         build-essential \
         bzr \
+        clang \
         cmake \
         curl \
         doxygen \

--- a/Dockerfile
+++ b/Dockerfile
@@ -478,8 +478,8 @@ RUN dotnet new
 ################################################################################
 WORKDIR /tmp
 RUN mkdir -p /opt/buildhome/.swift
-RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver ha.pool.sks-keyservers.net --recv-keys "$SWIFT_SIGNING_KEY" \
+ENV SWIFT_BIN_URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
+RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig"" -o swift.tar.gz.sig \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
     && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \

--- a/Dockerfile
+++ b/Dockerfile
@@ -475,18 +475,11 @@ RUN dotnet new
 # Swift
 #
 ################################################################################
-WORKDIR /tmp
-RUN mkdir -p /opt/buildhome/.swift
-ENV SWIFT_BIN_URL="https://swift.org/builds/swift-5.1.3-release/ubuntu1604/swift-5.1.3-RELEASE/swift-5.1.3-RELEASE-ubuntu16.04.tar.gz"
-RUN wget -q -O - https://swift.org/keys/all-keys.asc | \
-    gpg --import -
-RUN curl -fsL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_BIN_URL.sig" -o swift.tar.gz.sig \
-    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
-    && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
-    && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \
-    && rm swift.tar.gz.sig swift.tar.gz
-ENV PATH "$PATH:/opt/buildhome/.swift/usr/bin"
-ENV SWIFT_ROOT "/opt/buildhome/.swift"
+USER buildbot
+ENV SWIFTENV_ROOT="/opt/buildhome/.swiftenv"
+RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
+ENV PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
+RUN swiftenv install 5.1.3
 RUN swift --version
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -469,6 +469,25 @@ ENV PATH "$PATH:/opt/buildhome/.dotnet"
 ENV DOTNET_ROOT "/opt/buildhome/.dotnet"
 #populate local package cache
 RUN dotnet new
+
+
+################################################################################
+#
+# Swift
+#
+################################################################################
+WORKDIR /tmp
+RUN mkdir -p /opt/buildhome/.swift
+RUN curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver ha.pool.sks-keyservers.net --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    && tar -xzf swift.tar.gz --directory /opt/buildhome/.swift --strip-components=1 \
+    && chmod -R o+r /opt/buildhome/.swift/usr/lib/swift \
+    && rm swift.tar.gz.sig swift.tar.gz
+ENV PATH "$PATH:/opt/buildhome/.swift/usr/bin"
+ENV SWIFT_ROOT "/opt/buildhome/.swift"
+#populate local package cache
+RUN swift --version
 WORKDIR /
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -475,7 +475,7 @@ RUN dotnet new
 #
 ################################################################################
 USER buildbot
-ENV NETLIFY_BUILD_SWIFT_VERSION 5.1.3
+ENV NETLIFY_BUILD_SWIFT_VERSION 5.2
 ENV SWIFTENV_ROOT "/opt/buildhome/.swiftenv"
 RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
 ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"

--- a/included_software.md
+++ b/included_software.md
@@ -26,7 +26,7 @@ The specific patch versions included will depend on when the image was last buil
   * 1.12 (default)
 * Swift - `SWIFT_VERSION`, `.swift-version`
   * 5.2 (default)
-  * Any version that `swiftenv` can install.
+  * Any version that `swiftenv` can install newer than `4.x`. Versions `4.x` and below will not work due to incompatible shared libraries.
 * Java
   * 8 (default)
 * Emacs

--- a/included_software.md
+++ b/included_software.md
@@ -25,7 +25,7 @@ The specific patch versions included will depend on when the image was last buil
 * Go - `GO_VERSION`
   * 1.12 (default)
 * Swift - `SWIFT_VERSION`, `.swift-version`
-  * 5.1.3 (default)
+  * 5.2 (default)
   * Any version that `swiftenv` can install.
 * Java
   * 8 (default)

--- a/included_software.md
+++ b/included_software.md
@@ -24,6 +24,9 @@ The specific patch versions included will depend on when the image was last buil
   * 7.4
 * Go - `GO_VERSION`
   * 1.12 (default)
+* Swift - `SWIFT_VERSION`, `.swift-version`
+  * 5.1.3 (default)
+  * Any version that `swiftenv` can install.
 * Java
   * 8 (default)
 * Emacs

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -411,12 +411,10 @@ install_dependencies() {
     SWIFT_VERSION=$(cat .swift-version)
     echo "Attempting Swift version '$SWIFT_VERSION' from .swift-version"
   fi
-
   
   if [ -f $SWIFTENV_ROOT/versions/$SWIFT_VERSION/usr/bin/swift ] || swiftenv install $SWIFT_VERSION
   then
-    SWIFT_VERSION=$(swiftenv version)
-    export SWIFT_VERSION=$SWIFT_VERSION
+    echo "Using Swift version $SWIFT_VERSION"
   else
     echo "Failed to install Swift version '$SWIFT_VERSION'"
     exit 1

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -39,6 +39,7 @@ mkdir -p $NETLIFY_CACHE_DIR/.bundle
 mkdir -p $NETLIFY_CACHE_DIR/bower_components
 mkdir -p $NETLIFY_CACHE_DIR/.venv
 mkdir -p $NETLIFY_CACHE_DIR/wapm_packages
+mkdir -p $NETLIFY_CACHE_DIR/.build
 
 # HOME caches
 mkdir -p $NETLIFY_CACHE_DIR/.yarn_cache
@@ -401,6 +402,20 @@ install_dependencies() {
     fi
   fi
 
+  # SPM dependencies
+  if [ -f Package.swift ]
+  then
+    echo "Building Swift Package"
+    restore_cwd_cache ".build" "spm cache"
+    if swift build
+    then
+      echo "Swift package Built"
+    else
+      echo "Error building Swift package"
+      exit 1
+    fi
+  fi
+
   # NPM Dependencies
   : ${YARN_VERSION="$defaultYarnVersion"}
 
@@ -628,6 +643,7 @@ cache_artifacts() {
   cache_cwd_directory "node_modules" "node modules"
   cache_cwd_directory ".venv" "python virtualenv"
   cache_cwd_directory "wapm_packages", "wapm packages"
+  cache_cwd_directory ".build", "spm cache"
 
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache" "pip cache"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -406,7 +406,7 @@ install_dependencies() {
   if [ -f Package.swift ]
   then
     echo "Building Swift Package"
-    restore_cwd_cache ".build" "spm cache"
+    restore_cwd_cache ".build" "swift build"
     if swift build
     then
       echo "Swift package Built"
@@ -643,7 +643,7 @@ cache_artifacts() {
   cache_cwd_directory "node_modules" "node modules"
   cache_cwd_directory ".venv" "python virtualenv"
   cache_cwd_directory "wapm_packages", "wapm packages"
-  cache_cwd_directory ".build", "spm cache"
+  cache_cwd_directory ".build", "swift build"
 
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache" "pip cache"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -416,11 +416,12 @@ install_dependencies() {
   swiftenv global ${SWIFT_VERSION} > /dev/null 2>&1
   export CUSTOM_SWIFT=$?
 
-  if [ -d $NETLIFY_CACHE_DIR/swift_version/${SWIFT_VERSION} ]
+  if [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
   then
     echo "Started restoring cached Swift version"
     rm -rf $SWIFTENV_ROOT/versions/$SWIFT_VERSION
     cp -p -r $NETLIFY_CACHE_DIR/swift_version/${SWIFT_VERSION} $SWIFTENV_ROOT/versions/
+    swiftenv rehash
     echo "Finished restoring cached Swift version"
   fi
   

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -164,6 +164,7 @@ install_dependencies() {
   local defaultYarnVersion=$3
   local defaultPHPVersion=$4
   local installGoVersion=$5
+  local defaultSwiftVersion=$6
 
   # Python Version
   if [ -f runtime.txt ]
@@ -403,13 +404,16 @@ install_dependencies() {
     fi
   fi
 
+  # Swift Version
+  : ${SWIFT_VERSION="$defaultSwiftVersion"}
   if [ -f .swift-version ]
   then
     SWIFT_VERSION=$(cat .swift-version)
     echo "Attempting Swift version '$SWIFT_VERSION' from .swift-version"
   fi
 
-  if swiftenv install $SWIFT_VERSION
+  
+  if [ -f $SWIFTENV_ROOT/versions/$SWIFT_VERSION/usr/bin/swift ] || swiftenv install $SWIFT_VERSION
   then
     SWIFT_VERSION=$(swiftenv version)
     export SWIFT_VERSION=$SWIFT_VERSION

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -412,7 +412,7 @@ install_dependencies() {
     echo "Attempting Swift version '$SWIFT_VERSION' from .swift-version"
   fi
   
-  if [ -f $SWIFTENV_ROOT/versions/$SWIFT_VERSION/usr/bin/swift ] || swiftenv install $SWIFT_VERSION
+  if swiftenv install -s $SWIFT_VERSION
   then
     echo "Using Swift version $SWIFT_VERSION"
   else

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -642,8 +642,8 @@ cache_artifacts() {
   cache_cwd_directory "bower_components" "bower components"
   cache_cwd_directory "node_modules" "node modules"
   cache_cwd_directory ".venv" "python virtualenv"
-  cache_cwd_directory "wapm_packages", "wapm packages"
-  cache_cwd_directory ".build", "swift build"
+  cache_cwd_directory "wapm_packages" "wapm packages"
+  cache_cwd_directory ".build" "swift build"
 
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache" "pip cache"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -17,6 +17,7 @@ export GIMME_CGO_ENABLED=true
 
 export NVM_DIR="$HOME/.nvm"
 export RVM_DIR="$HOME/.rvm"
+export SWIFTENV_ROOT="${SWIFTENV_ROOT:-${HOME}/.swiftenv}"
 
 # Pipenv configuration
 export PIPENV_RUNTIME=2.7
@@ -400,6 +401,21 @@ install_dependencies() {
       echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
       exit 1
     fi
+  fi
+
+  if [ -f .swift-version ]
+  then
+    SWIFT_VERSION=$(cat .swift-version)
+    echo "Attempting Swift version '$SWIFT_VERSION' from .swift-version"
+  fi
+
+  if swiftenv install $SWIFT_VERSION
+  then
+    SWIFT_VERSION=$(swiftenv version)
+    export SWIFT_VERSION=$SWIFT_VERSION
+  else
+    echo "Failed to install Swift version '$SWIFT_VERSION'"
+    exit 1
   fi
 
   # SPM dependencies

--- a/run-build.sh
+++ b/run-build.sh
@@ -26,7 +26,7 @@ cd $NETLIFY_REPO_DIR
 : ${SWIFT_VERSION="5.1.3"}
 
 echo "Installing dependencies"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $SWIFT_VERSION 
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $SWIFT_VERSION
 
 echo "Installing missing commands"
 install_missing_commands

--- a/run-build.sh
+++ b/run-build.sh
@@ -23,9 +23,10 @@ cd $NETLIFY_REPO_DIR
 : ${YARN_VERSION="1.13.0"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
+: ${SWIFT_VERSION="5.1.3"}
 
 echo "Installing dependencies"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $SWIFT_VERSION 
 
 echo "Installing missing commands"
 install_missing_commands

--- a/run-build.sh
+++ b/run-build.sh
@@ -23,7 +23,7 @@ cd $NETLIFY_REPO_DIR
 : ${YARN_VERSION="1.13.0"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
-: ${SWIFT_VERSION="5.1.3"}
+: ${SWIFT_VERSION="5.2"}
 
 echo "Installing dependencies"
 install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $SWIFT_VERSION

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -11,6 +11,7 @@ docker run --rm -t -i \
 	-e HUGO_VERSION \
 	-e PHP_VERSION \
 	-e GO_VERSION \
+	-e SWIFT_VERSION \
 	-v ${REPO_PATH}:/opt/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -11,7 +11,6 @@ docker run --rm -t -i \
 	-e HUGO_VERSION \
 	-e PHP_VERSION \
 	-e GO_VERSION \
-	-e SWIFT_VERSION \
 	-v ${REPO_PATH}:/opt/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -23,7 +23,6 @@ fi
 : ${HUGO_VERSION="0.54.0"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
-: ${SWIFT_VERSION="5.1.3"}
 
 BASE_PATH=$(pwd)
 REPO_PATH="$(cd $1 && pwd)"

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -23,7 +23,7 @@ fi
 : ${HUGO_VERSION="0.54.0"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
-: ${SWIFT_VERSION="5.1.3"}
+: ${SWIFT_VERSION="5.2"}
 
 BASE_PATH=$(pwd)
 REPO_PATH="$(cd $1 && pwd)"

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -23,6 +23,7 @@ fi
 : ${HUGO_VERSION="0.54.0"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
+: ${SWIFT_VERSION="5.1.3"}
 
 BASE_PATH=$(pwd)
 REPO_PATH="$(cd $1 && pwd)"
@@ -51,6 +52,7 @@ docker run --rm \
        -e NETLIFY_VERBOSE \
        -e GO_VERSION \
        -e GO_IMPORT_PATH \
+       -e SWIFT_VERSION \
        -v "${REPO_PATH}:/opt/repo" \
        -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
        -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -51,7 +51,6 @@ docker run --rm \
        -e NETLIFY_VERBOSE \
        -e GO_VERSION \
        -e GO_IMPORT_PATH \
-       -e SWIFT_VERSION \
        -v "${REPO_PATH}:/opt/repo" \
        -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
        -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \


### PR DESCRIPTION
This PR adds Apple's Swift Programming Language & Swift Package Manager support to the Netlify Build image.  For those of you not aware, Swift is a programming language commonly used among developers on Apple's platforms (iOS, macOS, etc.) and has some server side traction via web frameworks such as Vapor.

On the Docker side, I've added a few steps to download & extract the Swift binary, along with a small sanity check.  As with NVM on NodeJS & RVM on Ruby, I've used [swiftenv](https://github.com/kylef/swiftenv) so you don't need to hardcode Ubuntu version to the Docker file & so a user can override Swift version via a `.swift-version` file or `SWIFT_VERSION` environment variable (the current readily available stable version, 5.2, is installed by default).

On the `run-build-functions.sh` side, I've added a `swift build` command if there's a `Package.swift` file, which does all the Swift Package Manager stuff.  The `.build` folder would be cached, except that as raised in #318 & #320, it seems like `cache_artifacts` is no longer run from `run-build.sh` at least when run locally.

Finally, I've fixed a small bug around the "wapm packages" cache - a trailing comma is added to the directory name & so it isn't cached if `cache_artifacts` is run.

You can find a small sample project at [SimonRice/PlotSample](https://github.com/SimonRice/PlotSample), which has a build command of `swift run` that generates an HTML file in a directory (innovatively) named `html` - in addition, @johnsundell (a prominent developer in the iOS & Swift community) has recently launched a very promising static site generator in Swift called Publish that can generate a bunch of HTML pages by running `swift run` - I know a lot of iOS developers would love to see this working on Netlify.