### PR TITLE
Don't install documentation when installing bundler

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -303,7 +303,7 @@ install_dependencies() {
       else
           bundler_gem_name="bundler:$bundler_version"
       fi
-      if ! gem install "$bundler_gem_name"
+      if ! gem install "$bundler_gem_name" --no-document
       then
           echo "Error installing bundler"
           exit 1


### PR DESCRIPTION
This prevents valuable seconds going to waste for every Ruby build that includes a Gemfile.lock with a line starting `BUNDLED WITH` (likely every Ruby build). The documentation is even (re)installed if the version of bundler already exists in the cache.

Here's a snippet from a current build log (note the line "Done installing documentation for bundler after 6 seconds"):

```
3:16:16 PM: Required ruby-2.6.5 is not installed.
3:16:16 PM: To install do: 'rvm install "ruby-2.6.5"'
3:16:16 PM: Attempting ruby version 2.6.5, read from .ruby-version file
3:16:16 PM: Started restoring cached ruby version
3:16:17 PM: Finished restoring cached ruby version
3:16:20 PM: Using ruby version 2.6.5
3:16:20 PM: Using bundler version 2.0.2 from Gemfile.lock
3:16:28 PM: Successfully installed bundler-2.0.2
3:16:28 PM: Parsing documentation for bundler-2.0.2
3:16:28 PM: Installing ri documentation for bundler-2.0.2
3:16:28 PM: Done installing documentation for bundler after 6 seconds
3:16:28 PM: 1 gem installed
3:16:28 PM: Using PHP version 5.6
3:16:28 PM: Started restoring cached ruby gems
3:16:28 PM: Finished restoring cached ruby gems
```

I can confirm that if you repeatedly run `gem install bundler:2.0.2` it will repeatedly parse and install the documentation, when `--no-document` is included the gem is still repeatedly (re)installed (though with no additional network access as it exists in rubygem's local cache) but no documentation is installed.