### PR TITLE
change volumes to delegated

### DIFF
--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -51,9 +51,9 @@ docker run --rm \
        -e NETLIFY_VERBOSE \
        -e GO_VERSION \
        -e GO_IMPORT_PATH \
-       -v "${REPO_PATH}:/opt/repo" \
-       -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
-       -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \
+       -v "${REPO_PATH}:/opt/repo:delegated" \
+       -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build:delegated" \
+       -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh:delegated" \
        -v $PWD/$T/cache:/opt/buildhome/cache \
        -w /opt/build \
        -it \


### PR DESCRIPTION
Docker on MacOS has a known performance limitation for mounted volumes.  This creates a performance issue for the build-image, as dependency installs will cause many mounted volume edits.  Docker addresses this with the delegated option on mounts.  It has not effect on other OSes.