### PR TITLE
Only remove Netlify Build's Node version if it's cached

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -191,7 +191,19 @@ install_dependencies() {
   if [[ $(ls $NETLIFY_CACHE_DIR/node_version/) ]]
   then
     echo "Started restoring cached node version"
-    rm -rf $NVM_DIR/versions/node/*
+    local nvm_versions_dir="$NVM_DIR/versions/node"
+    # only remove the version used by netlify-build if it also exists
+    # in the cache
+    if [ -d "$NETLIFY_CACHE_DIR/node_version/v$NETLIFY_BUILD_NODE_VERSION" ]
+    then
+        rm -rf $nvm_versions_dir/*
+    else
+        find "$nvm_versions_dir" -maxdepth 1 \
+             -type d \
+             -not -name "v$NETLIFY_BUILD_NODE_VERSION" \
+             -not -path "$nvm_versions_dir" \
+             -exec rm -rf {} \;
+    fi
     cp -p -r $NETLIFY_CACHE_DIR/node_version/* $NVM_DIR/versions/node/
     echo "Finished restoring cached node version"
   fi


### PR DESCRIPTION
Previously, `install_dependencies` was unconditionally removing all the versions of Node that were installed, including the pinned version for `netlify-build`, and replacing them with the cached Node versions. This was causing `netlify-build` to use the user's Node version, not its own pinned Node version. We should only remove the version of Node used by `netlify-build` if it also exists in the cache that we're restoring.