### PR TITLE
Add Racket Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -494,12 +494,6 @@ RUN wget --output-document=racket-install.sh -q https://mirror.racket-lang.org/i
     echo "yes\n1\n" | sh racket-install.sh --create-dir --unix-style --dest /usr/ && \
     rm racket-install.sh
 
-# RUN raco pkg config --set catalogs \
-#     "https://download.racket-lang.org/releases/7.6/catalog/" \
-#     "https://pkg-build.racket-lang.org/server/built/catalog/" \
-#     "https://pkgs.racket-lang.org" \
-#     "https://planet-compats.racket-lang.org"
-
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -484,6 +484,25 @@ RUN swift --version
 
 WORKDIR /
 
+################################################################################
+#
+# Racket
+#
+################################################################################
+# Based on https://github.com/jackfirth/racket-docker
+
+USER buildbot
+
+RUN wget --output-document=racket-install.sh -q https://mirror.racket-lang.org/installers/7.6/racket-7.6-x86_64-linux.sh && \
+    echo "yes\n1\n" | sh racket-install.sh --create-dir --unix-style --dest /usr/ && \
+    rm racket-install.sh
+
+RUN raco pkg config --set catalogs \
+    "https://download.racket-lang.org/releases/7.6/catalog/" \
+    "https://pkg-build.racket-lang.org/server/built/catalog/" \
+    "https://pkgs.racket-lang.org" \
+    "https://planet-compats.racket-lang.org"
+
 # Cleanup
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -488,17 +488,18 @@ RUN swift --version
 ################################################################################
 # Based on https://github.com/jackfirth/racket-docker
 
-USER buildbot
+USER root
 
 RUN wget --output-document=racket-install.sh -q https://mirror.racket-lang.org/installers/7.6/racket-7.6-x86_64-linux.sh && \
     echo "yes\n1\n" | sh racket-install.sh --create-dir --unix-style --dest /usr/ && \
     rm racket-install.sh
 
-RUN raco pkg config --set catalogs \
-    "https://download.racket-lang.org/releases/7.6/catalog/" \
-    "https://pkg-build.racket-lang.org/server/built/catalog/" \
-    "https://pkgs.racket-lang.org" \
-    "https://planet-compats.racket-lang.org"
+# RUN raco pkg config --set catalogs \
+#     "https://download.racket-lang.org/releases/7.6/catalog/" \
+#     "https://pkg-build.racket-lang.org/server/built/catalog/" \
+#     "https://pkgs.racket-lang.org" \
+#     "https://planet-compats.racket-lang.org"
+
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -490,7 +490,9 @@ RUN swift --version
 
 USER root
 
-RUN wget --output-document=racket-install.sh -q https://mirror.racket-lang.org/installers/7.6/racket-7.6-x86_64-linux.sh && \
+ENV RACKET_VERSION "7.6"
+
+RUN wget --output-document=racket-install.sh -q https://mirror.racket-lang.org/installers/${RACKET_VERSION}/racket-${RACKET_VERSION}-x86_64-linux.sh && \
     echo "yes\n1\n" | sh racket-install.sh --create-dir --unix-style --dest /usr/ && \
     rm racket-install.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -468,7 +468,6 @@ ENV DOTNET_ROOT "/opt/buildhome/.dotnet"
 #populate local package cache
 RUN dotnet new
 
-
 ################################################################################
 #
 # Swift
@@ -481,8 +480,6 @@ RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
 ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 RUN swiftenv install ${NETLIFY_BUILD_SWIFT_VERSION}
 RUN swift --version
-
-WORKDIR /
 
 ################################################################################
 #
@@ -502,6 +499,8 @@ RUN raco pkg config --set catalogs \
     "https://pkg-build.racket-lang.org/server/built/catalog/" \
     "https://pkgs.racket-lang.org" \
     "https://planet-compats.racket-lang.org"
+
+WORKDIR /
 
 # Cleanup
 USER root

--- a/included_software.md
+++ b/included_software.md
@@ -35,6 +35,8 @@ The specific patch versions included will depend on when the image was last buil
   * 21 (default)
 * Elixir
   * 1.7 (default)
+* Racket
+  * 7.6 (default)
 
 ### Tools
 

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -662,6 +662,19 @@ install_dependencies() {
     rm -rf $GOPATH/src/$GO_IMPORT_PATH
     ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
   fi
+
+  if [ -n info.rkt ]
+  then
+    raco setup
+    if [ $? -eq 0 ]
+    then
+      echo "Racket dependencies installed"
+    else
+      echo "Error during Racket dependencies install"
+      exit 1
+    fi
+  fi
+    
 }
 
 #

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -663,6 +663,7 @@ install_dependencies() {
     ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
   fi
 
+  # Install Racket Dependencies
   if [ -n info.rkt ]
   then
     raco setup


### PR DESCRIPTION
This PR adds support for [Racket](https://racket-lang.org/), which has some great tools around writing and publishing.

1. [Scribble](https://docs.racket-lang.org/scribble/) can be used to write any kind of docs. Instead of being a markup language, it's a full programming language.
1. [Pollen](https://docs.racket-lang.org/pollen/) is a publishing system for web books that can also be printed. Like Scribble, it gives full Racket support in the markup, making it powerful. It also supports Markdown.
1. [Frog](https://docs.racket-lang.org/frog/index.html) is a static site generator with blog support.

There are many other writing tools provided by Racket, while Racket also gives the ability to create your own language.