### PR TITLE
Add NETLIFY_IMAGE_TAG; add start-xenial.sh & start-trusty.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,41 +23,81 @@ Emulating Netlify's buildbot on your local machine requires the following:
 - A local clone of this build-image repository
 - A local clone of the site repository you want to test, checked out to the branch you want to be built, with a clean git status (nothing to commit).
 
-### Step 1: Pull the build image
-
-Open your Docker terminal, and run the following command to pull the default image:
+To run the `xenial` image, run the following command:
 
 ```
-docker pull netlify/build:xenial
-or
-docker pull netlify/build:v3.0.2 # replace the version with a git tag of the specific version you want to test
+./test-tools/start-xenial.sh path/to/site/repo
 ```
 
-### Step 2: Start the script to run interactively
-
-Still in your Docker terminal, change directories into your local clone of this build-image repository.
-
-If you pulled an alternate image in Step 1, check out the corresponding branch in this repository.
-
-Run the following command to start the interactive shell within the container:
+To run the `trusty` image, run the following command:
 
 ```
-./test-tools/start-image.sh path/to/site/repo
+./test-tools/start-trusty.sh path/to/site/repo
 ```
 
 If you receive a `command not found` message, make sure you are in the base of the build-image repository.
 
 If the command works correctly, you should see a new prompt, with the user `buildbot`.
 
-### Step 3: Have the buildbot run your build command
-
-In the buildbot shell, run `build` followed by your site build command. For example, for a site build command of `npm run build`, you would run the following:
+Finally, in the buildbot shell, run `build` followed by your site build command. For example, for a site build command of `npm run build`, you would run the following:
 
 ```
 build npm run build
 ```
 
 This will run the build as it would run on Netlify, displaying logs in your terminal as it goes. When you are done testing, you can exit the buildbot shell by typing `exit`.
+
+## Running a different tag or image
+
+To run a Docker tag other than `xenial` or `trustry`, first pull the image:
+
+```
+docker pull netlify/build:v3.0.2 # replace the version with a git tag of the specific version you want to test
+```
+
+Next, run `test-tools/start-image.sh` with the environment variable `NETLIFY_IMAGE_TAG` set to the tag you just pulled:
+
+```
+NETLIFY_IMAGE_TAG=v3.0.2 ./test-tools/start-image.sh path/to/site/repo
+```
+
+To run a different Docker image name that you've pulled or built locally, run `test-tools/start-image.sh` with the environment variable `NETLIFY_IMAGE` set to the image and tag you wish to use:
+
+```
+NETLIFY_IMAGE=some-other-image:latest ./test-tools/start-image.sh path/to/site/repo
+```
+
+Note that `NETLIFY_IMAGE_TAG` has no effect when `NETLIFY_IMAGE` is defined.
+
+## Building and running locally
+
+If you would like to build the image locally, you can do so with Docker. In the root of this repository, run the following:
+
+```
+docker build -t netlify/build .
+```
+
+Next, run the image you just built with `test-tools/start-image.sh`:
+
+```
+./test-tools/start-image.sh path/to/site/repo
+```
+
+If you want to build and run using a specific tag, do the following:
+
+```
+docker build -t netlify/build:a-tag .
+NETLIFY_IMAGE_TAG=a-tag ./test-tools/start-image.sh path/to/site/repo
+```
+
+If you want to use an entirely separate image name, do the following:
+
+```
+docker build -t another-image-name .
+NETLIFY_IMAGE=another-image-name ./test-tools/start-image.sh path/to/site/repo
+```
+
+Note that `NETLIFY_IMAGE_TAG` has no effect if `NETLIFY_IMAGE` is defined.
 
 ### Build environment variables
 

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
-BASE_PATH=$(pwd)
-REPO_PATH=$(cd $1 && pwd)
+BASE_PATH="$(pwd)"
+REPO_PATH="$(cd $1 && pwd)"
+
+if [ -z "$NETLIFY_IMAGE" ]
+then
+   if [ -n "$NETLIFY_IMAGE_TAG" ]
+   then
+       NETLIFY_IMAGE="netlify/build:$NETLIFY_IMAGE_TAG"
+   else
+       NETLIFY_IMAGE="netlify/build:latest"
+   fi
+fi
 
 docker run --rm -t -i \
 	-e NODE_VERSION \
@@ -11,7 +21,7 @@ docker run --rm -t -i \
 	-e HUGO_VERSION \
 	-e PHP_VERSION \
 	-e GO_VERSION \
-	-v ${REPO_PATH}:/opt/repo \
-	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
-	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
-	netlify/build /bin/bash
+	-v "${REPO_PATH}":/opt/repo \
+	-v "${BASE_PATH}"/run-build.sh:/usr/local/bin/build \
+	-v "${BASE_PATH}"/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
+	"$NETLIFY_IMAGE" /bin/bash

--- a/test-tools/start-trusty.sh
+++ b/test-tools/start-trusty.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+docker pull netlify/build:trusty
+export NETLIFY_IMAGE_TAG=trusty
+exec "$DIR/start-image.sh" $@

--- a/test-tools/start-xenial.sh
+++ b/test-tools/start-xenial.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+docker pull netlify/build:xenial
+export NETLIFY_IMAGE_TAG=xenial
+exec "$DIR/start-image.sh" $@

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -15,7 +15,16 @@ then
   set -x
 fi
 
-: ${NETLIFY_IMAGE="netlify/build"}
+if [ -z "$NETLIFY_IMAGE" ]
+then
+   if [ -n "$NETLIFY_IMAGE_TAG" ]
+   then
+       NETLIFY_IMAGE="netlify/build:$NETLIFY_IMAGE_TAG"
+   else
+       NETLIFY_IMAGE="netlify/build:latest"
+   fi
+fi
+
 : ${NODE_VERSION="10"}
 : ${RUBY_VERSION="2.6.2"}
 : ${YARN_VERSION="1.13.0"}
@@ -24,7 +33,7 @@ fi
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.12"}
 
-BASE_PATH=$(pwd)
+BASE_PATH="$(pwd)"
 REPO_PATH="$(cd $1 && pwd)"
 
 mkdir -p tmp
@@ -54,7 +63,7 @@ docker run --rm \
        -v "${REPO_PATH}:/opt/repo" \
        -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
        -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \
-       -v $PWD/$T/cache:/opt/buildhome/cache \
+       -v "$PWD"/"$T"/cache:/opt/buildhome/cache \
        -w /opt/build \
        -it \
-       $NETLIFY_IMAGE $SCRIPT
+       "$NETLIFY_IMAGE" $SCRIPT


### PR DESCRIPTION
start-xenial.sh and start-trusty.sh both pull the image before running
it and set an explicit docker tag so that you don't end up using the
remote version of "latest", which is often out of date.

See also https://community.netlify.com/t/python-support-needs-to-improve/9617/8