### PR TITLE
add asciidoctor to the build node, useful for hugo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y --no-install-recommends \
         advancecomp \
         apache2-utils \
+        asciidoctor \
         autoconf \
         automake \
         bison \


### PR DESCRIPTION
Addressing this one: https://community.netlify.com/t/provide-asciidoc-asciidoctor-on-the-builder-nodes/12133