### PR TITLE
Add support for Julia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -484,3 +484,17 @@ ENV NF_IMAGE_VERSION ${NF_IMAGE_VERSION:-latest}
 
 ARG NF_IMAGE_TAG
 ENV NF_IMAGE_TAG ${NF_IMAGE_TAG:-latest}
+
+################################################################################
+#
+# Julia
+#
+################################################################################
+ENV JULIA_VERSION 1.4
+
+RUN mkdir /opt/julia-${JULIA_VERSION} && \
+    cd /tmp && \
+    wget -q https://julialang-s3.julialang.org/bin/linux/x64/`echo ${JULIA_VERSION} | cut -d. -f 1,2`/julia-${JULIA_VERSION}-linux-x86_64.tar.gz && \
+    tar xzf julia-${JULIA_VERSION}-linux-x86_64.tar.gz -C /opt/julia-${JULIA_VERSION} --strip-components=1 && \
+    rm /tmp/julia-${JULIA_VERSION}-linux-x86_64.tar.gz
+RUN ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia


### PR DESCRIPTION
This adds support for [Julia](https://julialang.org/). [[Github](https://github.com/julialang)]

Julia has many many packages (more than 3000)! And almost every other package has documentation written in [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl). Julia also has a static site generator [Franklin.jl](https://github.com/tlienart/Franklin.jl) which is quite unique and is improving a lot.

In fact the [main Julia site](https://julialang.org/) is generated using Franklin.jl.

With this, I think it would be very helpful for us to have Julia support on Netlify.