### PR TITLE
Add support for fgallery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         emacs25-nox \
         esl-erlang \
         expect \
+        fgallery \
         fontconfig \
         fontconfig-config \
         g++ \

--- a/included_software.md
+++ b/included_software.md
@@ -69,3 +69,4 @@ The specific patch versions included will depend on when the image was last buil
 * [Doxygen](http://www.doxygen.org) - 1.8.6
 * [WASMER](https://github.com/wasmerio/wasmer)
 * [WAPM](https://github.com/wasmerio/wapm-cli)
+* [fgallery](https://www.thregr.org/~wavexx/software/fgallery/)


### PR DESCRIPTION
#### Description
This PR adds support for `fgallery` to the Netlify build image. 

#### How it's done
- Add fgallery to Dockerfile 
- Add fgallery to included_software.md

#### Tests
Manually tested by building the Dockerfile and running a test script that uses `fgallery`.

#### Related issues
This is a follow-up on #396.