### PR TITLE
Fix nvm progress bar split on several lines

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -222,7 +222,7 @@ install_dependencies() {
     echo "Attempting node version '$NODE_VERSION' from .node-version"
   fi
 
-  if nvm install $NODE_VERSION
+  if nvm install --no-progress $NODE_VERSION
   then
     NODE_VERSION=$(nvm current)
     # no echo needed because nvm does that for us


### PR DESCRIPTION
nvm progress bar is currently split on several lines due to issues with logging. See discussion [here](https://github.com/netlify/buildbot/issues/601#issuecomment-620087992).

![nvm](https://user-images.githubusercontent.com/8136211/80404818-0d83dd00-88c2-11ea-9648-19108c809b2c.png)

This PR fixes it by adding the `--no-progress` CLI flag to `nvm`.