### PR TITLE
Fix "swiftenv install"

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -425,7 +425,9 @@ install_dependencies() {
     echo "Finished restoring cached Swift version"
   fi
   
-  if swiftenv install -s $SWIFT_VERSION
+  # swiftenv expects the following environment variables to refer to
+  # swiftenv internals
+  if PLATFORM= URL= VERSION= swiftenv install -s $SWIFT_VERSION
   then
     echo "Using Swift version $SWIFT_VERSION"
   else


### PR DESCRIPTION
Don't pass `PLATFORM`, `URL`, or `VERSION` environment variables to `swiftenv install`. `swiftenv` expects those environment variables to refer to `swiftenv` internals (see https://github.com/kylef/swiftenv/issues/170).

See also #364.