### PR TITLE
Add Lua support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libxss1 \
         libxtst6 \
         libyaml-dev \
+        lua5.1 \
+        lua5.3 \
+        luajit \
         mercurial \
         nasm \
         openjdk-8-jdk \
@@ -266,10 +269,20 @@ USER root
 
 ################################################################################
 #
-# Node.js
+# Lua
 #
 ################################################################################
 
+# Lua is already installed by apt-get above, so just set an
+# environment variable indicating the default version. 5.3 and luajit
+# are still available, but must be run explicitly.
+ENV LUA_VERSION=5.1
+
+################################################################################
+#
+# Node.js
+#
+################################################################################
 
 RUN curl -o- -L https://yarnpkg.com/install.sh > /usr/local/bin/yarn-installer.sh
 


### PR DESCRIPTION
Installs `lua5.1` (which is also available as `lua`), `lua5.3`, and `luajit`.

Does not install [LuaRocks](https://luarocks.org/), Lua's community package manager. This is because it isn't clear how to install LuaRocks in a way that would work for more than one installed version of Lua. The current version of LuaRocks expects Lua 5.3, but the `lua` CLI that's installed by apt is Lua 5.1.

Also evaluated https://dhavalkapil.com/luaver/, but that doesn't appear to be currently maintained and is significantly more complicated than this PR.