### PR TITLE
Default to xenial tag for testing

### DIFF
--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -2,6 +2,7 @@
 
 BASE_PATH=$(pwd)
 REPO_PATH=$(cd $1 && pwd)
+: ${NETLIFY_IMAGE="netlify/build:xenial"}
 
 docker run --rm -t -i \
 	-e NODE_VERSION \
@@ -15,4 +16,4 @@ docker run --rm -t -i \
 	-v ${REPO_PATH}:/opt/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
-	netlify/build /bin/bash
+	$NETLIFY_IMAGE /bin/bash

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -15,7 +15,7 @@ then
   set -x
 fi
 
-: ${NETLIFY_IMAGE="netlify/build"}
+: ${NETLIFY_IMAGE="netlify/build:xenial"}
 : ${NODE_VERSION="10"}
 : ${RUBY_VERSION="2.6.2"}
 : ${YARN_VERSION="1.13.0"}


### PR DESCRIPTION
As reported in #402, the README suggests pulling `netlify/buildbot:xenial`, but the test script runs a test build with `netlify/buildbot:latest`. The `xenial` tag is our most up-to-date image and should be used for testing by default.

I think we should also apply the `latest` tag to `xenial`, since that's our latest image.