### PR TITLE
Tag xenial builds as latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,9 @@ pipeline {
           docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
             docker.image("netlify/build:${env.BRANCH_NAME}").push()
             docker.image("netlify/build:${env.GIT_COMMIT}").push()
+            if (env.BRANCH_NAME == 'xenial') {
+              docker.image("netlify/build:{$env.BRANCH_NAME}").push('latest')
+            }
           }
         }
       }


### PR DESCRIPTION
For now, xenial represents our most up-to-date build image. We should follow Docker conventions and tag it as latest.

Application of the `latest` tag is based on https://www.jenkins.io/doc/book/pipeline/docker/. I'm not a jenkins expert so feedback is welcome!