### PR TITLE
Add Intl for PHP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         php5.6-sqlite3 \
         php5.6-curl \
         php5.6-zip \
+        php5.6-intl \
         php7.2 \
         php7.2-xml \
         php7.2-mbstring \
@@ -152,6 +153,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         php7.2-sqlite3 \
         php7.2-curl \
         php7.2-zip \
+        php7.2-intl \
         php7.4 \
         php7.4-xml \
         php7.4-mbstring \
@@ -159,6 +161,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         php7.4-sqlite3 \
         php7.4-curl \
         php7.4-zip \
+        php7.4-intl \
         pngcrush \
         python-setuptools \
         python \


### PR DESCRIPTION
I try make a generator of static sites based on Sculpin. 

However, dependencies require the `intl` extension for using `localizeddate` filter in Twig templates (Documentation : https://twig-extensions.readthedocs.io/en/latest/intl.html#localizeddate).
It is not yet in the build image.
I think that a few projects also require this.

Adding it could be as simple as `sudo apt-get install php7.4-intl`.