### PR TITLE
Support installing tools via homebrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         emacs25-nox \
         esl-erlang \
         expect \
+        file \
         fontconfig \
         fontconfig-config \
         g++ \
@@ -468,7 +469,6 @@ ENV DOTNET_ROOT "/opt/buildhome/.dotnet"
 #populate local package cache
 RUN dotnet new
 
-
 ################################################################################
 #
 # Swift
@@ -481,6 +481,20 @@ RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
 ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 RUN swiftenv install ${NETLIFY_BUILD_SWIFT_VERSION}
 RUN swift --version
+
+################################################################################
+#
+# Homebrew
+#
+################################################################################
+USER buildbot
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+ENV PATH "/opt/buildhome/.linuxbrew/bin:$PATH"
+ENV HOMEBREW_PREFIX "/opt/buildhome/.linuxbrew"
+ENV HOMEBREW_CELLAR "/opt/buildhome/.linuxbrew/Cellar"
+ENV HOMEBREW_REPOSITORY "/opt/buildhome/.linuxbrew/Homebrew"
+ENV HOMEBREW_CACHE "/opt/buildhome/.homebrew-cache"
+RUN brew tap homebrew/bundle
 
 WORKDIR /
 

--- a/included_software.md
+++ b/included_software.md
@@ -72,3 +72,8 @@ The specific patch versions included will depend on when the image was last buil
 * [Doxygen](http://www.doxygen.org) - 1.8.6
 * [WASMER](https://github.com/wasmerio/wasmer)
 * [WAPM](https://github.com/wasmerio/wapm-cli)
+
+* [Homebrew](https://brew.sh/)
+  - Any linux formula is supported: https://formulae.brew.sh/formula-linux/
+  - Formulae from a `Brewfile` are installed automatically via [`brew bundle`](https://github.com/Homebrew/homebrew-bundle#readme)
+  - `HOMEBREW_BUNDLE_FILE` is respected

--- a/included_software.md
+++ b/included_software.md
@@ -73,7 +73,9 @@ The specific patch versions included will depend on when the image was last buil
 * [WASMER](https://github.com/wasmerio/wasmer)
 * [WAPM](https://github.com/wasmerio/wapm-cli)
 
-* [Homebrew](https://brew.sh/)
+* [Homebrew](https://brew.sh/) - **EARLY ALPHA**
+  - this is not production ready
+  - it might be removed or changed significantly
   - Any linux formula is supported: https://formulae.brew.sh/formula-linux/
   - Formulae from a `Brewfile` are installed automatically via [`brew bundle`](https://github.com/Homebrew/homebrew-bundle#readme)
   - `HOMEBREW_BUNDLE_FILE` is respected

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -453,6 +453,7 @@ install_dependencies() {
   # Homebrew from Brewfile
   if [ -f Brewfile ] || [ ! -z "$HOMEBREW_BUNDLE_FILE" ]
   then
+    echo "Installing Homebrew dependencies from ${HOMEBREW_BUNDLE_FILE:-Brewfile}"
     brew bundle
   fi
 

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -425,7 +425,7 @@ install_dependencies() {
     swiftenv rehash
     echo "Finished restoring cached Swift version"
   fi
-  
+
   # swiftenv expects the following environment variables to refer to
   # swiftenv internals
   if PLATFORM= URL= VERSION= swiftenv install -s $SWIFT_VERSION
@@ -448,6 +448,12 @@ install_dependencies() {
       echo "Error building Swift package"
       exit 1
     fi
+  fi
+
+  # Homebrew from Brewfile
+  if [ -f Brewfile ] || [ ! -z "$HOMEBREW_BUNDLE_FILE" ]
+  then
+    brew bundle
   fi
 
   # NPM Dependencies
@@ -664,12 +670,6 @@ install_dependencies() {
     mkdir -p "$(dirname $GOPATH/src/$GO_IMPORT_PATH)"
     rm -rf $GOPATH/src/$GO_IMPORT_PATH
     ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
-  fi
-
-  # Homebrew from Brewfile
-  if [ -f Brewfile ] || [ ! -z "$HOMEBREW_BUNDLE_FILE" ]
-  then
-    brew bundle
   fi
 }
 

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -54,6 +54,7 @@ mkdir -p $NETLIFY_CACHE_DIR/.composer
 mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gopath
 mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gocache
 mkdir -p $NETLIFY_CACHE_DIR/.wasmer/cache
+mkdir -p $NETLIFY_CACHE_DIR/.homebrew-cache
 
 : ${YARN_FLAGS=""}
 : ${NPM_FLAGS=""}
@@ -664,6 +665,12 @@ install_dependencies() {
     rm -rf $GOPATH/src/$GO_IMPORT_PATH
     ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
   fi
+
+  # Homebrew from Brewfile
+  if [ -f Brewfile ] || [ ! -z "$HOMEBREW_BUNDLE_FILE" ]
+  then
+    brew bundle
+  fi
 }
 
 #
@@ -686,6 +693,7 @@ cache_artifacts() {
   cache_home_directory ".boot" "boot dependencies"
   cache_home_directory ".composer" "composer dependencies"
   cache_home_directory ".wasmer/cache", "wasmer cache"
+  cache_home_directory ".homebrew-cache", "homebrew cache"
 
   # Don't follow the Go import path or we'll store
   # the origin repo twice.


### PR DESCRIPTION
Adding support for Homebrew aka Linuxbrew: https://docs.brew.sh/Homebrew-on-Linux

This shall be amazing because:
- It supports installing A LOT of tools without sudo: https://formulae.brew.sh/formula-linux/
- People can use a `Brewfile` in their git to specify dependencies

I also hope this will allow us to remove some lesser-used tooling from the image and offer users to install it via Homebrew instead.
Good candidates for that:
- pandoc
- hugo
- doxygen
- jq
- optipng
- asciidoctor
- emacs
- gifsicle
- graphicsmagick
- graphviz
- imagemagick
- jpegoptim
- pngcrush
- rsync
- sqlite3
- swig

## Test plan

Has been verified locally with `Brewfile` and custom Brewfile name via `$HOMEBREW_BUNDLE_FILE`

## Cute animal
![](https://source.unsplash.com/LNSIGPuZXIg/600x400)