### PR TITLE
Remove NETLIFY_BUILD_NODE_VERSION & special handling of its nvm dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -284,10 +284,7 @@ RUN git clone https://github.com/creationix/nvm.git ~/.nvm && \
 ENV ELM_VERSION=0.19.0-bugfix6
 ENV YARN_VERSION=1.13.0
 
-ENV NETLIFY_BUILD_NODE_VERSION="12.16.1"
-
 RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
-         nvm install --no-progress $NETLIFY_BUILD_NODE_VERSION && \
          nvm install --no-progress 10 && npm install -g sm grunt-cli bower elm@$ELM_VERSION && \
              bash /usr/local/bin/yarn-installer.sh --version $YARN_VERSION && \
          nvm alias default node && nvm cache clear"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -196,19 +196,7 @@ install_dependencies() {
   if [[ $(ls $NETLIFY_CACHE_DIR/node_version/) ]]
   then
     echo "Started restoring cached node version"
-    local nvm_versions_dir="$NVM_DIR/versions/node"
-    # only remove the version used by netlify-build if it also exists
-    # in the cache
-    if [ -d "$NETLIFY_CACHE_DIR/node_version/v$NETLIFY_BUILD_NODE_VERSION" ]
-    then
-        rm -rf $nvm_versions_dir/*
-    else
-        find "$nvm_versions_dir" -maxdepth 1 \
-             -type d \
-             -not -name "v$NETLIFY_BUILD_NODE_VERSION" \
-             -not -path "$nvm_versions_dir" \
-             -exec rm -rf {} \;
-    fi
+    rm -rf "$NVM_DIR/versions/node"
     cp -p -r $NETLIFY_CACHE_DIR/node_version/* $NVM_DIR/versions/node/
     echo "Finished restoring cached node version"
   fi


### PR DESCRIPTION
This is now installed in a separate location in a different layer of the build image. The `NETLIFY_BUILD_NODE_VERSION` behavior contained here is nonfunctional.

I moved this change out of https://github.com/netlify/build-image/pull/406 so it could be evaluated independently.