### PR TITLE
Cache `.netlify/plugins/` directory

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -42,6 +42,7 @@ mkdir -p $NETLIFY_CACHE_DIR/bower_components
 mkdir -p $NETLIFY_CACHE_DIR/.venv
 mkdir -p $NETLIFY_CACHE_DIR/wapm_packages
 mkdir -p $NETLIFY_CACHE_DIR/.build
+mkdir -p $NETLIFY_CACHE_DIR/.netlify/plugins
 
 # HOME caches
 mkdir -p $NETLIFY_CACHE_DIR/.yarn_cache
@@ -238,6 +239,9 @@ install_dependencies() {
       echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
     fi
   fi
+
+  # Automatically installed Build plugins
+  restore_cwd_cache ".netlify/plugins" "build plugins"
 
   # Ruby version
   local tmprv="${RUBY_VERSION:=$defaultRubyVersion}"
@@ -670,6 +674,7 @@ cache_artifacts() {
   cache_cwd_directory ".venv" "python virtualenv"
   cache_cwd_directory "wapm_packages" "wapm packages"
   cache_cwd_directory ".build" "swift build"
+  cache_cwd_directory ".netlify/plugins" "build plugins"
 
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache" "pip cache"


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/1281

When Build plugins cannot be found in the `build-image` pre-installed cached, and were not added to the `package.json`, `@netlify/build` automatically installs those.

At the moment, we install those in the build's main `node_modules`, but this creates many caching issues. Instead, we will now install those in `.netlify/plugins/node_modules`. A dummy `.netlify/plugins/package.json` is also created. 

Therefore `.netlify/plugins` should now be cached in the `build-image`. This PR implements this.