### PR TITLE
Fix `nvm` caching

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -201,6 +201,7 @@ install_dependencies() {
   then
     echo "Started restoring cached node version"
     rm -rf "$NVM_DIR/versions/node"
+    mkdir "$NVM_DIR/versions/node"
     cp -p -r $NETLIFY_CACHE_DIR/node_version/* $NVM_DIR/versions/node/
     echo "Finished restoring cached node version"
   fi


### PR DESCRIPTION
Fixes #426.

The following error currently happens when restoring the Node.js version:

```
2:20:09 PM: Started restoring cached node version
2:20:11 PM: cp: target '/opt/buildhome/.nvm/versions/node/' is not a directory
2:20:11 PM: Finished restoring cached node version
```

This PR fixes this.