### PR TITLE
Fix `.netlify/plugins` caching

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -237,6 +237,10 @@ install_dependencies() {
   fi
 
   # Automatically installed Build plugins
+  if [ ! -d "$PWD/.netlify" ]
+  then
+    mkdir "$PWD/.netlify"
+  fi
   restore_cwd_cache ".netlify/plugins" "build plugins"
 
   # Ruby version


### PR DESCRIPTION
The `.netlify/plugins/` directory is now cached since #424.

However, when restoring the plugins, we do a `mv` without creating the intermediary `.netlify` directory, which results in the following error:

```
9:31:51 PM: Started restoring cached build plugins
9:31:51 PM: mv: cannot move '/opt/build/cache/.netlify/plugins' to '/opt/build/repo/.netlify/plugins'
9:31:51 PM: No such file or directory
9:31:51 PM: Finished restoring cached build plugins
```

This PR fixes this.