### PR TITLE
Fix logs when caching `~/.cache`

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -374,7 +374,7 @@ install_dependencies() {
   if [ -f requirements.txt ]
   then
     echo "Installing pip dependencies"
-    restore_home_cache ".cache" "pip cache"
+    restore_home_cache ".cache" "~/.cache"
     if pip install -r requirements.txt
     then
       echo "Pip dependencies installed"
@@ -677,7 +677,7 @@ cache_artifacts() {
   cache_cwd_directory ".netlify/plugins" "build plugins"
 
   cache_home_directory ".yarn_cache" "yarn cache"
-  cache_home_directory ".cache" "pip cache"
+  cache_home_directory ".cache" "~/.cache"
   cache_home_directory ".cask" "emacs cask dependencies"
   cache_home_directory ".emacs.d" "emacs cache"
   cache_home_directory ".m2" "maven dependencies"


### PR DESCRIPTION
Fixes #353.

We are caching `~/.cache` but the logs show it as `pip cache`. `pip` is cached in `~/.cache/pip`.

I think it does make sense to cache anything in `~/.cache` as it is a convenient well-known cache location. Anything in there is intended for caching. It is [standardized as `$XDG_CACHE_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) by `freedesktop.org`. 

However we should rename it. This PR renames it to the path itself `~/.cache` since I am assuming this might be more precise and clearer to developers than `home cache`, `$HOME/cache`, `user cache` or `global cache`. But I am open to any suggestions, we just need another name than `pip`.