### PR TITLE
Make find_running_procs match the definition in buildbot

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -815,7 +815,7 @@ prep_functions() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct | grep -v "[build]"
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
 }
 
 report_lingering_procs() {


### PR DESCRIPTION
This will allow the redefinition of find_running_procs in buildbot to
be removed.