### PR TITLE
Preinstall Ruby 2.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,9 @@ ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 
 # Match this set latest Stable releases we can support on https://www.ruby-lang.org/en/downloads/
 ENV RUBY_VERSION=2.7.1
+# Also preinstall Ruby 2.6.2, as many customers are pinned to it and installing is slow
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
+                  rvm install 2.6.2 && \
                   rvm install $RUBY_VERSION && rvm use $RUBY_VERSION && gem install bundler && \
                   rvm use $RUBY_VERSION --default && rvm cleanup all"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -260,7 +260,7 @@ ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 ENV RUBY_VERSION=2.7.1
 # Also preinstall Ruby 2.6.2, as many customers are pinned to it and installing is slow
 RUN /bin/bash -c "source ~/.rvm/scripts/rvm && \
-                  rvm install 2.6.2 && \
+                  rvm install 2.6.2 && rvm use 2.6.2 && gem install bundler && \
                   rvm install $RUBY_VERSION && rvm use $RUBY_VERSION && gem install bundler && \
                   rvm use $RUBY_VERSION --default && rvm cleanup all"
 


### PR DESCRIPTION
Many users are still pinned to Ruby 2.6.2, and are seeing an error like
![ruby](https://user-images.githubusercontent.com/1887071/84947625-5cb6e480-b09f-11ea-8bb9-6d48779e9887.png)
Although we're defaulting to 2.7 for new sites, we should continue to preinstall 2.6.2 or most users builds will be slowed down by about 15 seconds, regardless of whether they're using Ruby.