### PR TITLE
Allow to force Yarn usage

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -458,7 +458,7 @@ install_dependencies() {
   if [ -f package.json ]
   then
     restore_cwd_cache node_modules "node modules"
-    if ([ -f yarn.lock ] && [ ! "$USE_YARN" = "false" ]) || [ "$USE_YARN" = "true" ]
+    if [ "$USE_YARN" = "true" ] || ([ "$USE_YARN" != "false" ] && [ -f yarn.lock ]) 
     then
       run_yarn $YARN_VERSION
     else
@@ -471,7 +471,7 @@ install_dependencies() {
   then
     if ! [ $(which bower) ]
     then
-      if ([ -f yarn.lock ] && [ ! "$USE_YARN" = "false" ]) || [ "$USE_YARN" = "true" ]
+      if [ "$USE_YARN" = "true" ] || ([ "$USE_YARN" != "false" ] && [ -f yarn.lock ]) 
       then
         echo "Installing bower with Yarn"
         yarn add bower

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -458,7 +458,7 @@ install_dependencies() {
   if [ -f package.json ]
   then
     restore_cwd_cache node_modules "node modules"
-    if [ -f yarn.lock ] || [ ! -z $USE_YARN ]
+    if ([ -f yarn.lock ] && [ ! "$USE_YARN" = "false" ]) || [ "$USE_YARN" = "true" ]
     then
       run_yarn $YARN_VERSION
     else
@@ -471,7 +471,7 @@ install_dependencies() {
   then
     if ! [ $(which bower) ]
     then
-      if [ -f yarn.lock ] || [ ! -z $USE_YARN ]
+      if ([ -f yarn.lock ] && [ ! "$USE_YARN" = "false" ]) || [ "$USE_YARN" = "true" ]
       then
         echo "Installing bower with Yarn"
         yarn add bower

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -458,7 +458,7 @@ install_dependencies() {
   if [ -f package.json ]
   then
     restore_cwd_cache node_modules "node modules"
-    if [ "$USE_YARN" = "true" ] || ([ "$USE_YARN" != "false" ] && [ -f yarn.lock ]) 
+    if [ "$NETLIFY_USE_YARN" = "true" ] || ([ "$NETLIFY_USE_YARN" != "false" ] && [ -f yarn.lock ]) 
     then
       run_yarn $YARN_VERSION
     else
@@ -471,7 +471,7 @@ install_dependencies() {
   then
     if ! [ $(which bower) ]
     then
-      if [ "$USE_YARN" = "true" ] || ([ "$USE_YARN" != "false" ] && [ -f yarn.lock ]) 
+      if [ "$NETLIFY_USE_YARN" = "true" ] || ([ "$NETLIFY_USE_YARN" != "false" ] && [ -f yarn.lock ]) 
       then
         echo "Installing bower with Yarn"
         yarn add bower

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -458,7 +458,7 @@ install_dependencies() {
   if [ -f package.json ]
   then
     restore_cwd_cache node_modules "node modules"
-    if [ -f yarn.lock ]
+    if [ -f yarn.lock ] || [ ! -z $USE_YARN ]
     then
       run_yarn $YARN_VERSION
     else
@@ -471,7 +471,7 @@ install_dependencies() {
   then
     if ! [ $(which bower) ]
     then
-      if [ -f yarn.lock ]
+      if [ -f yarn.lock ] || [ ! -z $USE_YARN ]
       then
         echo "Installing bower with Yarn"
         yarn add bower


### PR DESCRIPTION
This PR add a new environment variable that allows anyone to force the usage of yarn. It's a simple workaround of #196.

The current workaround for Yarn workspaces ([here](https://github.com/netlify/build-image/issues/196#issuecomment-562328172)) only works with Yarn v1, Yarn v2 use yarn.lock to determine the root of the project and so, setting a empty `yarn.lock` in a specific folder will fail.

I choose the env var `USE_YARN` but it could be anything really 😄.