### PR TITLE
Don't cache full .cache dir

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -46,7 +46,7 @@ mkdir -p $NETLIFY_CACHE_DIR/.netlify/plugins
 
 # HOME caches
 mkdir -p $NETLIFY_CACHE_DIR/.yarn_cache
-mkdir -p $NETLIFY_CACHE_DIR/.cache
+mkdir -p $NETLIFY_CACHE_DIR/.cache/pip
 mkdir -p $NETLIFY_CACHE_DIR/.cask
 mkdir -p $NETLIFY_CACHE_DIR/.emacs.d
 mkdir -p $NETLIFY_CACHE_DIR/.m2
@@ -380,7 +380,7 @@ install_dependencies() {
   if [ -f requirements.txt ]
   then
     echo "Installing pip dependencies"
-    restore_home_cache ".cache" "pip cache"
+    restore_home_cache ".cache/pip" "pip cache"
     if pip install -r requirements.txt
     then
       echo "Pip dependencies installed"
@@ -666,7 +666,7 @@ cache_artifacts() {
   cache_cwd_directory ".netlify/plugins" "build plugins"
 
   cache_home_directory ".yarn_cache" "yarn cache"
-  cache_home_directory ".cache" "pip cache"
+  cache_home_directory ".cache/pip" "pip cache"
   cache_home_directory ".cask" "emacs cask dependencies"
   cache_home_directory ".emacs.d" "emacs cache"
   cache_home_directory ".m2" "maven dependencies"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -46,7 +46,11 @@ mkdir -p $NETLIFY_CACHE_DIR/.netlify/plugins
 
 # HOME caches
 mkdir -p $NETLIFY_CACHE_DIR/.yarn_cache
-mkdir -p $NETLIFY_CACHE_DIR/.cache/pip
+if [[ "$NETLIFY_CACHE_PIP_SUBDIRECTORY" == "true" ]]; then
+  mkdir -p $NETLIFY_CACHE_DIR/.cache/pip
+else
+  mkdir -p $NETLIFY_CACHE_DIR/.cache
+fi
 mkdir -p $NETLIFY_CACHE_DIR/.cask
 mkdir -p $NETLIFY_CACHE_DIR/.emacs.d
 mkdir -p $NETLIFY_CACHE_DIR/.m2
@@ -380,7 +384,11 @@ install_dependencies() {
   if [ -f requirements.txt ]
   then
     echo "Installing pip dependencies"
-    restore_home_cache ".cache/pip" "pip cache"
+    if [[ "$NETLIFY_CACHE_PIP_SUBDIRECTORY" == "true" ]]; then
+      restore_home_cache ".cache/pip" "pip cache"
+    else
+      restore_home_cache ".cache" "pip cache"
+    fi
     if pip install -r requirements.txt
     then
       echo "Pip dependencies installed"
@@ -666,7 +674,11 @@ cache_artifacts() {
   cache_cwd_directory ".netlify/plugins" "build plugins"
 
   cache_home_directory ".yarn_cache" "yarn cache"
-  cache_home_directory ".cache/pip" "pip cache"
+  if [[ "$NETLIFY_CACHE_PIP_SUBDIRECTORY" == "true" ]]; then
+    cache_home_directory ".cache/pip" "pip cache"
+  else
+    cache_home_directory ".cache" "pip cache"
+  fi
   cache_home_directory ".cask" "emacs cask dependencies"
   cache_home_directory ".emacs.d" "emacs cache"
   cache_home_directory ".m2" "maven dependencies"


### PR DESCRIPTION
Pip caches files to `$home/.cache/pip`. In order to take advantage of the Pip cache, we cache all of `$home/.cache` at the end of each build.

At the start of the next build, we conditionally restore the `.cache` directory to the home directory if `requirements.txt` is present.

This has two problems:

1. We are caching everything in `.cache`, but only restoring it under certain conditions. This can mean uploading many files to the cache without any benefit.
2. Because of the way the filesystem for builds is organized, restoring large files from the Netlify cache to the home directory is slow. We want to avoid restoring many/large files to the home directory if possible.

This PR caches only the `pip` subdirectory of `.cache`.

~Marking WIP for testing.~

Internal issue: https://github.com/netlify/buildbot/issues/845