### PR TITLE
Move build binaries from /usr/local/bin to /opt/build/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -485,8 +485,9 @@ WORKDIR /
 USER root
 
 # Add buildscript for local testing
-ADD run-build-functions.sh /usr/local/bin/run-build-functions.sh
-ADD run-build.sh /usr/local/bin/build
+RUN mkdir -p /opt/build/bin
+ADD run-build-functions.sh /opt/build/bin/run-build-functions.sh
+ADD run-build.sh /opt/build/bin/build
 ADD buildbot-git-config /root/.gitconfig
 RUN rm -r /tmp/*
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you're having problems with your build, you can also use these tools to test 
 
 ## Available images
 
-Netlify maintains multiple build images for testing new development as well as supporting legacy builds. Each image uses a different version of Ubuntu Linux, with a slightly different list of included language and software versions. 
+Netlify maintains multiple build images for testing new development as well as supporting legacy builds. Each image uses a different version of Ubuntu Linux, with a slightly different list of included language and software versions.
 
 The following images are currently available:
 
@@ -54,7 +54,7 @@ If the command works correctly, you should see a new prompt, with the user `buil
 In the buildbot shell, run `build` followed by your site build command. For example, for a site build command of `npm run build`, you would run the following:
 
 ```
-build npm run build
+/opt/build/bin/build npm run build
 ```
 
 This will run the build as it would run on Netlify, displaying logs in your terminal as it goes. When you are done testing, you can exit the buildbot shell by typing `exit`.

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -788,7 +788,7 @@ set_go_import_path() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v "/opt/build/bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/opt/build/bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
 }
 
 report_lingering_procs() {

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -466,7 +466,7 @@ install_dependencies() {
   if [ -f package.json ]
   then
     restore_cwd_cache node_modules "node modules"
-    if [ "$NETLIFY_USE_YARN" = "true" ] || ([ "$NETLIFY_USE_YARN" != "false" ] && [ -f yarn.lock ]) 
+    if [ "$NETLIFY_USE_YARN" = "true" ] || ([ "$NETLIFY_USE_YARN" != "false" ] && [ -f yarn.lock ])
     then
       run_yarn $YARN_VERSION
     else
@@ -479,7 +479,7 @@ install_dependencies() {
   then
     if ! [ $(which bower) ]
     then
-      if [ "$NETLIFY_USE_YARN" = "true" ] || ([ "$NETLIFY_USE_YARN" != "false" ] && [ -f yarn.lock ]) 
+      if [ "$NETLIFY_USE_YARN" = "true" ] || ([ "$NETLIFY_USE_YARN" != "false" ] && [ -f yarn.lock ])
       then
         echo "Installing bower with Yarn"
         yarn add bower
@@ -788,7 +788,7 @@ set_go_import_path() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v "/opt/build/bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
 }
 
 report_lingering_procs() {

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -15,6 +15,6 @@ docker run --rm -t -i \
 	-e SWIFT_VERSION \
 	-e PYTHON_VERSION \
 	-v ${REPO_PATH}:/opt/repo \
-	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
-	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
+	-v ${BASE_PATH}/run-build.sh:/opt/build/bin/build \
+	-v ${BASE_PATH}/run-build-functions.sh:/opt/build/bin/run-build-functions.sh \
 	$NETLIFY_IMAGE /bin/bash

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -41,7 +41,7 @@ chmod +w $T
 mkdir -p $T/cache
 chmod a+w $T/cache
 
-SCRIPT="/usr/local/bin/build $2"
+SCRIPT="/opt/build/bin/build $2"
 
 docker run --rm \
        -e NODE_VERSION \
@@ -55,8 +55,8 @@ docker run --rm \
        -e GO_IMPORT_PATH \
        -e SWIFT_VERSION \
        -v "${REPO_PATH}:/opt/repo" \
-       -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
-       -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \
+       -v "${BASE_PATH}/run-build.sh:/opt/build/bin/build" \
+       -v "${BASE_PATH}/run-build-functions.sh:/opt/build/bin/run-build-functions.sh" \
        -v $PWD/$T/cache:/opt/buildhome/cache \
        -w /opt/build \
        -it \


### PR DESCRIPTION
This will remove them from the `PATH`, and hopefully reduce the number of builds that accidentally call the build binaries. A corresponding PR in buildbot is at https://github.com/netlify/buildbot/pull/861.