### PR TITLE
Move build binaries again (to /opt/build-bin this time)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -485,10 +485,9 @@ WORKDIR /
 USER root
 
 # Add buildscript for local testing
-ENV BUILD_BIN_DIR "/opt/build-bin"
-RUN mkdir -p ${BUILD_BIN_DIR}
-ADD run-build-functions.sh ${BUILD_BIN_DIR}/run-build-functions.sh
-ADD run-build.sh ${BUILD_BIN_DIR}/build
+RUN mkdir -p /opt/build-bin
+ADD run-build-functions.sh /opt/build-bin/run-build-functions.sh
+ADD run-build.sh /opt/build-bin/build
 ADD buildbot-git-config /root/.gitconfig
 RUN rm -r /tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -485,8 +485,10 @@ WORKDIR /
 USER root
 
 # Add buildscript for local testing
-ADD run-build-functions.sh /usr/local/bin/run-build-functions.sh
-ADD run-build.sh /usr/local/bin/build
+ENV BUILD_BIN_DIR "/opt/build-bin"
+RUN mkdir -p ${BUILD_BIN_DIR}
+ADD run-build-functions.sh ${BUILD_BIN_DIR}/run-build-functions.sh
+ADD run-build.sh ${BUILD_BIN_DIR}/build
 ADD buildbot-git-config /root/.gitconfig
 RUN rm -r /tmp/*
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If the command works correctly, you should see a new prompt, with the user `buil
 In the buildbot shell, run `build` followed by your site build command. For example, for a site build command of `npm run build`, you would run the following:
 
 ```
-build npm run build
+/opt/build-bin/build npm run build
 ```
 
 This will run the build as it would run on Netlify, displaying logs in your terminal as it goes. When you are done testing, you can exit the buildbot shell by typing `exit`.

--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -15,6 +15,6 @@ docker run --rm -t -i \
 	-e SWIFT_VERSION \
 	-e PYTHON_VERSION \
 	-v ${REPO_PATH}:/opt/repo \
-	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
-	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
+	-v ${BASE_PATH}/run-build.sh:/opt/build-bin/build \
+	-v ${BASE_PATH}/run-build-functions.sh:/opt/build-bin/run-build-functions.sh \
 	$NETLIFY_IMAGE /bin/bash

--- a/test-tools/test-build.sh
+++ b/test-tools/test-build.sh
@@ -41,7 +41,7 @@ chmod +w $T
 mkdir -p $T/cache
 chmod a+w $T/cache
 
-SCRIPT="/usr/local/bin/build $2"
+SCRIPT="/opt/build-bin/build $2"
 
 docker run --rm \
        -e NODE_VERSION \
@@ -55,8 +55,8 @@ docker run --rm \
        -e GO_IMPORT_PATH \
        -e SWIFT_VERSION \
        -v "${REPO_PATH}:/opt/repo" \
-       -v "${BASE_PATH}/run-build.sh:/usr/local/bin/build" \
-       -v "${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh" \
+       -v "${BASE_PATH}/run-build.sh:/opt/build-bin/build" \
+       -v "${BASE_PATH}/run-build-functions.sh:/opt/build-bin/run-build-functions.sh" \
        -v $PWD/$T/cache:/opt/buildhome/cache \
        -w /opt/build \
        -it \


### PR DESCRIPTION
`/opt/build/bin` was being overwritten in production, so it wasn't working as a location for the build binaries. It had to be reverted due to that. This PR moves them instead to `/opt/build-bin`.