### PR TITLE
Fix find_running_procs to exclude correct binary

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -788,7 +788,7 @@ set_go_import_path() {
 }
 
 find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/usr/local/bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
+  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/opt/build-bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
 }
 
 report_lingering_procs() {


### PR DESCRIPTION
This should have been in https://github.com/netlify/build-image/pull/460 but I missed it. This script is overridden in production, so this isn't very important, but it is a little misleading as is.