### PR TITLE
Cache cypress binary under node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -299,6 +299,8 @@ RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
              bash /usr/local/bin/yarn-installer.sh --version $YARN_VERSION && \
          nvm alias default node && nvm cache clear"
 
+ENV CYPRESS_CACHE_FOLDER="./node_modules/CypressBinary"
+
 USER root
 
 ################################################################################


### PR DESCRIPTION
Proposal to cache the Cypress binary under `node_modules`, which we persist to the build cache by default.

This configuration is [recommended](https://github.com/cypress-io/netlify-plugin-cypress#recommended) in the docs for netlify-plugin-cypress. This would turn it on for all users.

This is preferable to caching the default location of the Cypress binary (~/.cache) because it avoids copying across the partitions that exist in the build system.