### PR TITLE
Fix support for Yarn 2 (berry)

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -113,8 +113,8 @@ run_yarn() {
   then
     # The cache-folder flag is deprecated in Yarn 2
     # Override the environment variable if the user set any.
+    # To use the global cache, the user should set YARN_ENABLE_GLOBAL_CACHE
     export YARN_GLOBAL_FOLDER="$NETLIFY_BUILD_BASE/.yarn_cache"
-    export YARN_ENABLE_GLOBAL_CACHE=1
   else
     # Remove the cache-folder flag if the user set any.
     yarn_local="${yarn_local/--cache-folder * /}"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -85,7 +85,7 @@ run_yarn() {
   # Check the version of yarn installed globally
   if [ $(which yarn) ] && [ "$(YARN_IGNORE_PATH=1 yarn --version)" != "$yarn_version" ]
   then
-    echo "Found yarn version ($(yarn --version)) that doesn't match expected ($yarn_version)"
+    echo "Global yarn version ($(yarn --version)) that doesn't match expected ($yarn_version)"
     rm -rf $NETLIFY_CACHE_DIR/yarn $HOME/.yarn
     npm uninstall yarn -g
   fi

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -85,7 +85,7 @@ run_yarn() {
   # Check the version of yarn installed globally
   if [ $(which yarn) ] && [ "$(YARN_IGNORE_PATH=1 yarn --version)" != "$yarn_version" ]
   then
-    echo "Global yarn version ($(yarn --version)) that doesn't match expected ($yarn_version)"
+    echo "Global yarn version ($(yarn --version)) doesn't match expected ($yarn_version)"
     rm -rf $NETLIFY_CACHE_DIR/yarn $HOME/.yarn
     npm uninstall yarn -g
   fi


### PR DESCRIPTION
- Checks the version of Yarn installed globally using [`YARN_IGNORE_PATH=1`](https://yarnpkg.com/configuration/yarnrc#ignorePath). The environment variable `YARN_VERSION` sets the version of Yarn to install globally.
- Sets [`YARN_GLOBAL_FOLDER`](https://yarnpkg.com/configuration/yarnrc#globalFolder) environment variable to the cache directory. The `cache-folder` flag is deprecated in Yarn 2. The user can opt-in to use the global cache by setting [`YARN_ENABLE_GLOBAL_CACHE`](https://yarnpkg.com/configuration/yarnrc#enableGlobalCache) in Netlify settings. (See https://github.com/netlify/build-image/pull/465#discussion_r465539682)

Closes #319.

**Suggestion for Docs:**
https://docs.netlify.com/configure-builds/environment-variables/#netlify-configuration-variables
```diff
- * `YARN_VERSION`: Sets the [Yarn version].
+ * `YARN_VERSION`: Sets the [Yarn version] to install globally.
+ * `YARN_ENABLE_GLOBAL_CACHE`: Use the [global cache](https://yarnpkg.com/configuration/yarnrc#enableGlobalCache) for Yarn 2. 
```

https://docs.netlify.com/configure-builds/manage-dependencies/#yarn
```diff
- * `YARN_VERSION`: defaults to the version preinstalled with your initial [build image]. Accepts any released version number.
+ * `YARN_VERSION`: defaults to the version preinstalled with your initial [build image]. Accepts any released version number. The specified version is installed globally.
+ * `YARN_ENABLE_GLOBAL_CACHE`: whether to use the [global cache](https://yarnpkg.com/configuration/yarnrc#enableGlobalCache) for Yarn 2. If you use zero-installs, do not set this variable.
```

CC @arcanis Could you check whether this is the right way to use Yarn 2 in CI?