### PR TITLE
Cache Cypress in ./node_modules/.cache/CypressBinary

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -455,6 +455,7 @@ install_dependencies() {
   # NPM Dependencies
   : ${YARN_VERSION="$defaultYarnVersion"}
   : ${CYPRESS_CACHE_FOLDER="./node_modules/.cache/CypressBinary"}
+  export CYPRESS_CACHE_FOLDER
 
   if [ -f package.json ]
   then

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -454,6 +454,7 @@ install_dependencies() {
 
   # NPM Dependencies
   : ${YARN_VERSION="$defaultYarnVersion"}
+  : ${CYPRESS_CACHE_FOLDER="./node_modules/.cache/CypressBinary"}
 
   if [ -f package.json ]
   then


### PR DESCRIPTION
This will allow us to cache the Cypress binary in the same partition as the build by default and upload it to Netlify's cache automatically.

We're putting it under `./node_modules/.cache` rather than directly under `./node_modules` so it won't be pruned by `npm install`.