### PR TITLE
Document `PYTHON_VERSION` option

### DIFF
--- a/included_software.md
+++ b/included_software.md
@@ -14,7 +14,7 @@ The specific patch versions included will depend on when the image was last buil
 * Node.js - `NODE_VERSION`, `.nvmrc`, `.node-version`
   * 10 (default)
   * Any version that `nvm` can install.
-* Python - `runtime.txt` or `Pipfile`
+* Python - `PYTHON_VERSION`, `runtime.txt`, `Pipfile`
   * 2.7 (default)
   * 3.5
   * 3.7


### PR DESCRIPTION
Functionality added in https://github.com/netlify/build-image/pull/363

Contributes to the closure of https://github.com/netlify/docs/issues/616.

Adds `PYTHON_VERSION` as an option in the included software list, in the same format as other languages.