### PR TITLE
Remove lingering processes logic

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -905,24 +905,3 @@ set_go_import_path() {
     cd $importPath
   fi
 }
-
-find_running_procs() {
-  ps aux | grep -v [p]s | grep -v [g]rep | grep -v [b]ash | grep -v "/opt/build-bin/buildbot" | grep -v [d]efunct | grep -vw '\[build\]'
-}
-
-report_lingering_procs() {
-  procs=$(find_running_procs)
-  nprocs=$(expr $(echo "$procs" | wc -l) - 1)
-  if [[ $nprocs > 0 ]]; then
-    echo -e "${YELLOW}"
-    echo "** WARNING **"
-    echo "There are some lingering processes even after the build process finished: "
-    echo
-    echo "$procs"
-    echo
-    echo "Our builds do not kill your processes automatically, so please make sure"
-    echo "that nothing is running after your build finishes, or it will be marked as"
-    echo "failed since something is still running."
-    echo -e "${NC}"
-  fi
-}


### PR DESCRIPTION
This removes the lingering processes logic from the `build-image`.

The `build-image` only defines the function. The `buildbot` used to do the actual call. Both have been moved to `@netlify/build` in https://github.com/netlify/buildbot/pull/979.

https://github.com/netlify/buildbot/pull/979 remove the `buildbot` call to those functions, so this PR only cleans them up (they are now dead code). This PR can be reviewed, but it would be good to wait few days after https://github.com/netlify/buildbot/pull/979 to be released in production first, so we are sure the new logic works and we don't have to rollback the `build-image` in case of problems.