### PR TITLE
Bump elm version from 0.19.0 to 0.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -288,7 +288,7 @@ RUN git clone https://github.com/creationix/nvm.git ~/.nvm && \
     git checkout v$NVM_VERSION && \
     cd /
 
-ENV ELM_VERSION=0.19.0-bugfix6
+ENV ELM_VERSION=latest-0.19.1
 ENV YARN_VERSION=1.22.4
 
 ENV NETLIFY_NODE_VERSION="12.18.0"


### PR DESCRIPTION
Updates Elm version in the docker build image to the latest Elm version: 0.19.1 (was 0.19.0). Addresses #464

The author does not know if there is a reason that the Elm version was previously specified as 0.19.0.

