### PR TITLE
NETLIFY_INSTALL_JS_DEPENDENCIES skips npm dependency install

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -109,7 +109,7 @@ run_yarn() {
   # The previous pattern doesn't match the end of the string.
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
-  if [ "$SKIP_NPM_DEPENDENCY_INSTALL" != "true" ]
+  if [ "$NETLIFY_INSTALL_JS_DEPENDENCIES" != "false" ]
   then
     if yarn install --cache-folder $NETLIFY_BUILD_BASE/.yarn_cache ${yarn_local:+"$yarn_local"}
     then
@@ -149,7 +149,7 @@ run_npm() {
 
   if install_deps package.json $NODE_VERSION $NETLIFY_CACHE_DIR/package-sha
   then
-    if [ "$SKIP_NPM_DEPENDENCY_INSTALL" != "true" ]
+    if [ "$NETLIFY_INSTALL_JS_DEPENDENCIES" != "false" ]
     then
       echo "Installing NPM modules using NPM version $(npm --version)"
       run_npm_set_temp

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -119,7 +119,7 @@ run_yarn() {
       exit 1
     fi
   else
-    echo "Skipping NPM modules install"
+    echo "Skipping Node modules install"
   fi
   export PATH=$(yarn bin):$PATH
 }

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -99,7 +99,7 @@ run_yarn() {
   fi
 
 
-  echo "Installing NPM modules using Yarn version $(yarn --version)"
+  echo "Installing Node modules using Yarn version $(yarn --version)"
   run_npm_set_temp
 
   # Remove the cache-folder flag if the user set any.
@@ -113,7 +113,7 @@ run_yarn() {
   then
     if yarn install --cache-folder $NETLIFY_BUILD_BASE/.yarn_cache ${yarn_local:+"$yarn_local"}
     then
-      echo "NPM modules installed using Yarn"
+      echo "Node modules installed using Yarn"
     else
       echo "Error during Yarn install"
       exit 1
@@ -151,17 +151,17 @@ run_npm() {
   then
     if [ "$NETLIFY_INSTALL_JS_DEPENDENCIES" != "false" ]
     then
-      echo "Installing NPM modules using NPM version $(npm --version)"
+      echo "Installing Node modules using NPM version $(npm --version)"
       run_npm_set_temp
       if npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
       then
-        echo "NPM modules installed"
+        echo "Node modules installed"
       else
-        echo "Error during NPM install"
+        echo "Error during Node install"
         exit 1
       fi
     else
-      echo "Skipping NPM modules install"
+      echo "Skipping Node modules install"
     fi
 
     echo "$(shasum package.json)-$NODE_VERSION" > $NETLIFY_CACHE_DIR/package-sha


### PR DESCRIPTION
Setting ~SKIP_NPM_DEPENDENCY_INSTALL~ NETLIFY_INSTALL_JS_DEPENDENCIES to ~true~ false tells the build-image to skip installing npm dependencies (i.e. npm install or yarn install), while still making npm (or yarn if you have NETLIFY_USE_YARN set or have a yarn.lock) available to the build command.

This is non-build-plugin implementation that addresses the issue described here: https://github.com/netlify/build/issues/1149

fixes https://github.com/netlify/build-image/issues/493