### PR TITLE
Upgrade to the latest Clojure patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -375,7 +375,7 @@ RUN mkdir /opt/boot-clj && cd /opt/boot-clj && \
     chmod +x boot && \
     ln -s /opt/boot-clj/boot /usr/local/bin/boot
 
-RUN curl -sL https://download.clojure.org/install/linux-install-1.10.1.492.sh | bash
+RUN curl -sL https://download.clojure.org/install/linux-install-1.10.1.727.sh | bash
 
 USER buildbot
 


### PR DESCRIPTION
See https://clojure.org/guides/getting_started#_installation_on_linux. See the [changelog for Clojure](https://clojure.org/releases/tools) and [for tools.deps](https://github.com/clojure/tools.deps.alpha/blob/master/CHANGELOG.md).

Upgrades to the latest  tools.deps.alpha 0.9.821 (was 0.8.584), including support for directly executing clojure functions via `-X`.