### PR TITLE
Remove default Swift version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -465,12 +465,9 @@ RUN dotnet new
 #
 ################################################################################
 USER buildbot
-ENV NETLIFY_BUILD_SWIFT_VERSION 5.2
 ENV SWIFTENV_ROOT "/opt/buildhome/.swiftenv"
 RUN git clone --depth 1 https://github.com/kylef/swiftenv.git "$SWIFTENV_ROOT"
 ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
-RUN swiftenv install ${NETLIFY_BUILD_SWIFT_VERSION}
-RUN swift --version
 
 ################################################################################
 #

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -415,9 +415,6 @@ install_dependencies() {
     echo "Attempting Swift version '$SWIFT_VERSION' from .swift-version"
   fi
 
-  swiftenv global ${SWIFT_VERSION} > /dev/null 2>&1
-  export CUSTOM_SWIFT=$?
-
   if [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
   then
     echo "Started restoring cached Swift version"
@@ -429,12 +426,14 @@ install_dependencies() {
 
   # swiftenv expects the following environment variables to refer to
   # swiftenv internals
-  if PLATFORM= URL= VERSION= swiftenv install -s $SWIFT_VERSION
-  then
-    echo "Using Swift version $SWIFT_VERSION"
-  else
-    echo "Failed to install Swift version '$SWIFT_VERSION'"
-    exit 1
+  if [ -f .swift-version -o -f Package.swift ]
+    if PLATFORM= URL= VERSION= swiftenv install -s $SWIFT_VERSION
+    then
+      echo "Using Swift version $SWIFT_VERSION"
+    else
+      echo "Failed to install Swift version '$SWIFT_VERSION'"
+      exit 1
+    fi
   fi
 
   # SPM dependencies
@@ -700,7 +699,7 @@ cache_artifacts() {
   fi
 
   # cache the version of Swift installed
-  if [[ "$CUSTOM_SWIFT" -ne "0" ]]
+  if [ -d $SWIFTENV_ROOT/versions/$SWIFT_VERSION ]
   then
     if ! [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
     then

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -422,13 +422,12 @@ install_dependencies() {
 
   if [ -n "$SWIFT_VERSION" ]
   then
-    export SWIFT_VERSION=$SWIFT_VERSION
-
-    if [ -n "$SWIFT_VERSION" ] && [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
+    if [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
     then
+      mkdir -p "$SWIFTENV_ROOT/versions"
       echo "Started restoring cached Swift version"
-      rm -rf $SWIFTENV_ROOT/versions/$SWIFT_VERSION
-      cp -p -r $NETLIFY_CACHE_DIR/swift_version/${SWIFT_VERSION} $SWIFTENV_ROOT/versions/
+      rm -rf "$SWIFTENV_ROOT/versions/$SWIFT_VERSION"
+      cp -p -r "$NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION/" "$SWIFTENV_ROOT/versions/"
       swiftenv rehash
       echo "Finished restoring cached Swift version"
     fi

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -17,7 +17,10 @@ export GIMME_CGO_ENABLED=true
 
 export NVM_DIR="$HOME/.nvm"
 export RVM_DIR="$HOME/.rvm"
+
+# Swift configuration
 export SWIFTENV_ROOT="${SWIFTENV_ROOT:-${HOME}/.swiftenv}"
+DEFAULT_SWIFT_VERSION="5.2"
 
 # Pipenv configuration
 export PIPENV_RUNTIME=2.7
@@ -407,7 +410,6 @@ install_dependencies() {
   fi
 
   # Swift Version
-  defaultSwiftVersion="5.2"
   if [ -f .swift-version ]
   then
     SWIFT_VERSION=$(cat .swift-version)
@@ -417,7 +419,7 @@ install_dependencies() {
   # If Package.swift is present and no Swift version is set, use a default
   if [ -f Package.swift ]
   then
-    : ${SWIFT_VERSION="$defaultSwiftVersion"}
+    : ${SWIFT_VERSION="$DEFAULT_SWIFT_VERSION"}
   fi
 
   if [ -n "$SWIFT_VERSION" ]

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -426,8 +426,9 @@ install_dependencies() {
 
   # swiftenv expects the following environment variables to refer to
   # swiftenv internals
-  if [ -f .swift-version -o -f Package.swift ]
-    if PLATFORM= URL= VERSION= swiftenv install -s $SWIFT_VERSION
+  if [ -f .swift-version ] || [ -f Package.swift ]
+  then
+    if PLATFORM='' URL='' VERSION='' swiftenv install -s $SWIFT_VERSION
     then
       echo "Using Swift version $SWIFT_VERSION"
     else

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -424,9 +424,8 @@ install_dependencies() {
   then
     if [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
     then
-      mkdir -p "$SWIFTENV_ROOT/versions"
       echo "Started restoring cached Swift version"
-      rm -rf "$SWIFTENV_ROOT/versions/$SWIFT_VERSION"
+      mkdir -p "$SWIFTENV_ROOT/versions"
       cp -p -r "$NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION/" "$SWIFTENV_ROOT/versions/"
       swiftenv rehash
       echo "Finished restoring cached Swift version"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -705,13 +705,13 @@ cache_artifacts() {
   fi
 
   # cache the version of Swift installed
-  if [ -d $SWIFTENV_ROOT/versions/$SWIFT_VERSION ]
+  if [ -n "$SWIFT_VERSION" ] && [ -d "$SWIFTENV_ROOT/versions/$SWIFT_VERSION" ]
   then
     if ! [ -d $NETLIFY_CACHE_DIR/swift_version/$SWIFT_VERSION ]
     then
       rm -rf $NETLIFY_CACHE_DIR/swift_version
       mkdir $NETLIFY_CACHE_DIR/swift_version
-      mv $SWIFTENV_ROOT/versions/$SWIFT_VERSION $NETLIFY_CACHE_DIR/swift_version/
+      mv "$SWIFTENV_ROOT/versions/$SWIFT_VERSION" $NETLIFY_CACHE_DIR/swift_version/
       echo "Cached Swift version $SWIFT_VERSION"
     fi
   else

--- a/run-build.sh
+++ b/run-build.sh
@@ -23,11 +23,10 @@ cd $NETLIFY_REPO_DIR
 : ${YARN_VERSION="1.22.4"}
 : ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.14.4"}
-: ${SWIFT_VERSION="5.2"}
 : ${PYTHON_VERSION="2.7"}
 
 echo "Installing dependencies"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $SWIFT_VERSION $PYTHON_VERSION
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $PYTHON_VERSION
 
 echo "Installing missing commands"
 install_missing_commands


### PR DESCRIPTION
Swift is used by few users and accounts for 23% of the size of our base build image. This PR keeps automatic install of Swift during builds, but drops the default version (5.2) from the build image.

With this change, users will need to specify that a build requires Swift in one of three ways:

1. Set the `SWIFT_VERSION` environment variable to the desired version.
2. Include a `.swift-version` file in the build directory.
3. Include a `Package.swift` file in the build directory. If no `.swift-version` file or `SWIFT_VERSION` environment variable is present, we'll default to installing version 5.2.

See https://community.netlify.com/t/upcoming-change-builds-will-no-longer-install-swift-5-2-by-default
Example builds at https://github.com/netlify/buildbot/pull/1055