### PR TITLE
Disable npm audit in npm install

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -136,7 +136,7 @@ run_npm() {
     then
       echo "Found npm version ($(npm --version)) that doesn't match expected ($NPM_VERSION)"
       echo "Installing npm at version $NPM_VERSION"
-      if npm install -g npm@$NPM_VERSION
+      if npm install --no-audit -g npm@$NPM_VERSION
       then
         echo "NPM installed successfully"
       else


### PR DESCRIPTION
npm audit is a development tool, here the only thing it does is slow down the build.

npm install by default is a development tool, so it includes features like audit that need to be manually disabled if we do not use npm ci.