### PR TITLE
Fix npm caching issues

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -146,20 +146,16 @@ run_npm() {
     fi
   fi
 
-  if install_deps package.json $NODE_VERSION $NETLIFY_CACHE_DIR/package-sha
+  echo "Installing NPM modules using NPM version $(npm --version)"
+  run_npm_set_temp
+  if npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
   then
-    echo "Installing NPM modules using NPM version $(npm --version)"
-    run_npm_set_temp
-    if npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
-    then
-      echo "NPM modules installed"
-    else
-      echo "Error during NPM install"
-      exit 1
-    fi
-
-    echo "$(shasum package.json)-$NODE_VERSION" > $NETLIFY_CACHE_DIR/package-sha
+    echo "NPM modules installed"
+  else
+    echo "Error during NPM install"
+    exit 1
   fi
+
   export PATH=$(npm bin):$PATH
 }
 


### PR DESCRIPTION
npm install is optimized for the development process and if node_modules is in a correct state,
npm install will quit quickly after checking the status of the cache.

Removing the conditional will prevent breakages related to stale cache, like in #113.

After including #509, on a mid-size project with a laptop npm install quits after 1.5s for me.

Also closes #523.