### PR TITLE
Switch to npm ci

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -146,20 +146,16 @@ run_npm() {
     fi
   fi
 
-  if install_deps package.json $NODE_VERSION $NETLIFY_CACHE_DIR/package-sha
+  echo "Installing NPM modules using NPM version $(npm --version)"
+  run_npm_set_temp
+  if npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
   then
-    echo "Installing NPM modules using NPM version $(npm --version)"
-    run_npm_set_temp
-    if npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
-    then
-      echo "NPM modules installed"
-    else
-      echo "Error during NPM install"
-      exit 1
-    fi
-
-    echo "$(shasum package.json)-$NODE_VERSION" > $NETLIFY_CACHE_DIR/package-sha
+    echo "NPM modules installed"
+  else
+    echo "Error during NPM install"
+    exit 1
   fi
+
   export PATH=$(npm bin):$PATH
 }
 

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -150,13 +150,21 @@ run_npm() {
 
   echo "Installing NPM modules using NPM version $(npm --version)"
   run_npm_set_temp
-  if npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
+  if [ -f package-lock.json ]
   then
-    echo "NPM modules installed"
+    if ! npm ci
+    then
+      echo "Error during NPM ci"
+      exit 1
+    fi
   else
-    echo "Error during NPM install"
-    exit 1
+    if ! npm install ${NPM_FLAGS:+"$NPM_FLAGS"}
+    then
+      echo "Error during NPM install"
+      exit 1
+    fi
   fi
+  echo "NPM modules installed"
 
   export PATH=$(npm bin):$PATH
 }

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -145,6 +145,8 @@ run_npm() {
       fi
     fi
   fi
+  
+  restore_home_cache ".npm" "npm cache"
 
   if install_deps package.json $NODE_VERSION $NETLIFY_CACHE_DIR/package-sha
   then
@@ -677,6 +679,7 @@ cache_artifacts() {
   cache_cwd_directory ".netlify/plugins" "build plugins"
   cache_cwd_directory "target" "rust compile output"
 
+  cache_home_directory ".npm" "npm cache"
   cache_home_directory ".yarn_cache" "yarn cache"
   cache_home_directory ".cache/pip" "pip cache"
   cache_home_directory ".cask" "emacs cask dependencies"


### PR DESCRIPTION
`npm install` is somewhat meant for interactive runs. Here are some reasons to avoid it:
  - it runs a developer-focused audit by default, and while we can disable the audit (#509), there may be more similar features running in the background now or in the future;
  - it is not always meant to be deterministic in a way one would expect from an automated deployment, resulting in unexpected behavior for our users (#172, [forum topic](https://community.netlify.com/t/how-can-i-use-npm-ci-instead-of-npm-install/12570));
  - is difficult to cache correctly, resulting in stale cache and breakages (#113, #165, #510);

`npm ci` is [meant for automated deployments](https://docs.npmjs.com/cli/v7/commands/npm-ci) and does not suffer from the same issues. Instead, it manages its own cache (#511) and ensures a deterministic result.

It still is slower than an npm install under ideal conditions, but it might be less of a concern than previously expected. With the npm cache (#511), an npm ci on a mid-size project on a laptop takes 7-8s for me as opposed to 2-3s for npm install. The command also runs offline, retrieving all packages from the cache.

This PR might be breaking for some user-provided NPM_FLAGS. As npm ci does not take any options, we may be disabling some functionality users expected. An overview of the existing npm install options brings these, probably unlikely, cases:
  - Users with `--dry-run` and package-lock.json will suddenly have their dependencies installed. Assuming they also install their dependencies themselves in a separate step, this will not impact their build success, but will slow it down by adding duplicate effort;
  - Users with `--no-package-lock` will get older versions of dependencies than they expect, likely breaking their builds;
  - Users with `--omit` will get more dependencies than they expect, probably not impacting their build success, but slowing it down;
  - Users with `--ignore-scripts` may have their builds slow down or possibly break.

Closes #113, #114, #165, #172, #509, #510, #511.
