### PR TITLE
add webp to lfs config

### DIFF
--- a/buildbot-git-config
+++ b/buildbot-git-config
@@ -1,5 +1,5 @@
 [lfs]
-	fetchinclude = *.jpg,*.png,*.jpeg,*.svg,*.gif,*.pdf,*.mp4,*.bmp
+	fetchinclude = *.jpg,*.png,*.jpeg,*.svg,*.gif,*.pdf,*.mp4,*.bmp,*.webp
 [filter "lfs"]
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f


### PR DESCRIPTION
Since webp is a modern alternative to the already included jpg, png and gif which is [supported](https://caniuse.com/webp) by all modern browsers, I think it makes sense to include it by default as well. 