### PR TITLE
feat: better cache support for JS workspaces

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -108,9 +108,11 @@ run_yarn() {
   if [ "$NETLIFY_YARN_WORKSPACES" = "true" ]
   then
     echo "NETLIFY_YARN_WORKSPACES feature flag set"
+    local workspace_output
     # YARN_IGNORE_PATH will ignore the presence of a local yarn executable (i.e. yarn 2) and default
     # to using the global one (which, for now, is alwasy yarn 1.x). See https://yarnpkg.com/configuration/yarnrc#ignorePath
-    if YARN_IGNORE_PATH=1 yarn workspaces info
+    workspace_output=$(YARN_IGNORE_PATH=1 yarn workspaces info)
+    if $?
     then
       local package_locations
       # Extract all the packages and respective locations. .data will be a JSON object like
@@ -123,7 +125,7 @@ run_yarn() {
       #   (...)
       # }
       # We need to cache all the node_module dirs, or we'll always be installing them on each run
-      mapfile -t package_locations <<< "$(YARN_IGNORE_PATH=1 yarn --json workspaces info | jq -r '.data | fromjson | to_entries | .[].value.location')"
+      mapfile -t package_locations <<< "$workspace_output"
       restore_js_workspaces_cache "${package_locations[@]}"
     else
       echo "No workspace detected"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -109,10 +109,12 @@ run_yarn() {
   then
     echo "NETLIFY_YARN_WORKSPACES feature flag set"
     local workspace_output
+    local workspace_exit_code
     # YARN_IGNORE_PATH will ignore the presence of a local yarn executable (i.e. yarn 2) and default
     # to using the global one (which, for now, is alwasy yarn 1.x). See https://yarnpkg.com/configuration/yarnrc#ignorePath
-    workspace_output=$(YARN_IGNORE_PATH=1 yarn workspaces info)
-    if $?
+    workspace_output="$(YARN_IGNORE_PATH=1 yarn workspaces --json info )"
+    workspace_exit_code=$?
+    if [ $workspace_exit_code -eq 0 ]
     then
       local package_locations
       # Extract all the packages and respective locations. .data will be a JSON object like
@@ -125,7 +127,7 @@ run_yarn() {
       #   (...)
       # }
       # We need to cache all the node_module dirs, or we'll always be installing them on each run
-      mapfile -t package_locations <<< "$workspace_output"
+      mapfile -t package_locations <<< "$(echo "$workspace_output" | jq -r '.data | fromjson | to_entries | .[].value.location')"
       restore_js_workspaces_cache "${package_locations[@]}"
     else
       echo "No workspace detected"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -39,8 +39,10 @@ mkdir -p $NETLIFY_CACHE_DIR/ruby_version
 mkdir -p $NETLIFY_CACHE_DIR/swift_version
 
 # pwd caches
+NETLIFY_JS_WORKSPACES_CACHE_DIR="$NETLIFY_CACHE_DIR/js-workspaces"
+
+mkdir -p $NETLIFY_JS_WORKSPACES_CACHE_DIR
 mkdir -p $NETLIFY_CACHE_DIR/node_modules
-mkdir -p $NETLIFY_CACHE_DIR/js-workspaces
 mkdir -p $NETLIFY_CACHE_DIR/.bundle
 mkdir -p $NETLIFY_CACHE_DIR/bower_components
 mkdir -p $NETLIFY_CACHE_DIR/.venv
@@ -827,14 +829,14 @@ restore_js_workspaces_cache() {
   # Keep a record of the workspaces in the project in order to cache them later
   NETLIFY_JS_WORKSPACE_LOCATIONS=("$@")
 
-  local cache_dir="$NETLIFY_CACHE_DIR/js-workspaces"
-
   # Retrieve each workspace node_modules
   for location in "${NETLIFY_JS_WORKSPACE_LOCATIONS[@]}"; do
-    move_cache "$cache_dir/$location/node_modules" "$NETLIFY_REPO_DIR/$location/node_modules" "restoring workspace $location node modules"
+    move_cache "$NETLIFY_JS_WORKSPACES_CACHE_DIR/$location/node_modules" \
+      "$NETLIFY_REPO_DIR/$location/node_modules" \
+      "restoring workspace $location node modules"
   done
   # Retrieve hoisted node_modules
-  move_cache "$cache_dir/node_modules" "$NETLIFY_REPO_DIR/node_modules" "restoring workspace root node modules"
+  move_cache "$NETLIFY_JS_WORKSPACES_CACHE_DIR/node_modules" "$NETLIFY_REPO_DIR/node_modules" "restoring workspace root node modules"
 }
 
 #
@@ -856,14 +858,14 @@ cache_node_modules() {
 # `NETLIFY_JS_WORKSPACE_LOCATIONS` variable previously set in `restore_js_workspaces_cache()`
 #
 cache_js_workspaces() {
-  local cache_dir="$NETLIFY_CACHE_DIR/js-workspaces"
-
   for location in "${NETLIFY_JS_WORKSPACE_LOCATIONS[@]}"; do
-    mkdir -p "$cache_dir/$location"
-    move_cache "$NETLIFY_REPO_DIR/$location/node_modules" "$cache_dir/$location/node_modules" "saving workspace $location node modules"
+    mkdir -p "$NETLIFY_JS_WORKSPACES_CACHE_DIR/$location"
+    move_cache "$NETLIFY_REPO_DIR/$location/node_modules" \
+      "$NETLIFY_JS_WORKSPACES_CACHE_DIR/$location/node_modules" \
+      "saving workspace $location node modules"
   done
   # Retrieve hoisted node_modules
-  move_cache "$NETLIFY_REPO_DIR/node_modules" "$cache_dir/node_modules" "saving workspace root node modules"
+  move_cache "$NETLIFY_REPO_DIR/node_modules" "$NETLIFY_JS_WORKSPACES_CACHE_DIR/node_modules" "saving workspace root node modules"
 }
 
 cache_cwd_directory() {

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -60,10 +60,6 @@ mkdir -p $NETLIFY_CACHE_DIR/.gimme_cache/gocache
 mkdir -p $NETLIFY_CACHE_DIR/.homebrew-cache
 mkdir -p $NETLIFY_CACHE_DIR/.cargo
 
-
-# tmp dir
-NETLIFY_TMP_DIR=$(mktemp -d)
-
 : ${YARN_FLAGS=""}
 : ${NPM_FLAGS=""}
 : ${BUNDLER_FLAGS=""}
@@ -838,30 +834,30 @@ restore_js_workspaces_cache() {
   # Retrieve hoisted node_modules
   move_cache "$cache_dir/node_modules" "$NETLIFY_REPO_DIR/node_modules" "restoring workspace root node modules"
   # Keep a record of the workspaces in the project in order to cache them later
-  printf '%s\n' "${locations[@]}" > "$NETLIFY_TMP_DIR/.workspace_locations"
+  NETLIFY_JS_WORKSPACE_LOCATIONS=$(printf '%s\n' "${locations[@]}")
 }
 
 #
 # Caches node_modules dirs for a js project. Either detects the presence of js workspaces
-# via the `.workspace_locations` file, or looks at the node_modules in the cwd.
+# via the `NETLIFY_JS_WORKSPACE_LOCATIONS` variable, or looks at the node_modules in the cwd.
 #
 cache_node_modules() {
-  if [ -f "$NETLIFY_TMP_DIR/.workspace_locations" ]
+  if [ -z "$NETLIFY_JS_WORKSPACE_LOCATIONS" ]
   then
-    cache_js_workspaces
-  else
     cache_cwd_directory "node_modules" "node modules"
+  else
+    cache_js_workspaces
   fi
 }
 
 #
 # Caches node_modules dirs from js workspaces. It acts based on the presence of a
-# `.workspace_locations` file previously generated in `restore_js_workspaces_cache()`
+# `NETLIFY_JS_WORKSPACE_LOCATIONS` variable previously set in `restore_js_workspaces_cache()`
 #
 cache_js_workspaces() {
   local cache_dir="$NETLIFY_CACHE_DIR/js-workspaces"
   local locations
-  mapfile -t locations <<< "$(cat "$NETLIFY_TMP_DIR/.workspace_locations")"
+  mapfile -t locations <<< "$NETLIFY_JS_WORKSPACE_LOCATIONS"
 
   for location in "${locations[@]}"; do
     mkdir -p "$cache_dir/$location"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -111,7 +111,7 @@ run_yarn() {
     local workspace_output
     local workspace_exit_code
     # YARN_IGNORE_PATH will ignore the presence of a local yarn executable (i.e. yarn 2) and default
-    # to using the global one (which, for now, is alwasy yarn 1.x). See https://yarnpkg.com/configuration/yarnrc#ignorePath
+    # to using the global one (which, for now, is always yarn 1.x). See https://yarnpkg.com/configuration/yarnrc#ignorePath
     workspace_output="$(YARN_IGNORE_PATH=1 yarn workspaces --json info )"
     workspace_exit_code=$?
     if [ $workspace_exit_code -eq 0 ]


### PR DESCRIPTION
Based on the discussion started in https://github.com/netlify/pod-workflow/issues/139 (which is in turn based on a lot of the open PRs and issues in this repo), this PR adds support for [js workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).

Despite being a feature originally supported by `yarn` only, `npm v7` is [catching up](https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/), with on-going discussions and RFCs (see https://github.com/npm/rfcs/pull/117 and https://github.com/npm/rfcs/pull/273) to add further functionality. These however still work differently, `npm` is unable to detect it is within a project with multiple workspaces if we `cd` into a sub-directory. For `netlify` (if we use the [`base` configuration property](https://docs.netlify.com/configure-builds/file-based-configuration/#sample-file)) our caching strategy still holds up, since we just install and cache a workspace package as it was a regular js project. For `yarn` however, installs in sub directories are able to infer they're part of a `workspace`, meaning dependencies will be hoisted and all the sibling packages will be installed also. This means that, in order to achieve the same caching experience we have for other JS projects, we need to cache the root `node_modules` as well as all the workspace `node_modules`.

This solution works for both `yarn v1` and `yarn v2` (that [rely on `node_modules` `nodeLinker` config](https://yarnpkg.com/configuration/yarnrc#nodeLinker)).

I've put in place an env variable - `NETLIFY_YARN_WORKSPACES` - that we can rely on to use as feature flag by hooking this up in the `buildbot` side with launch darkly.

Addresses #399 #432 #196 #479 #196 

## Tests

I've run this locally on a monorepo using:
- [yarn](https://github.com/JGAntunes/gatsby-yarn-netlify-test/tree/multiple-netlify-sites-yarn)
- [yarn v2](https://github.com/JGAntunes/gatsby-yarn-netlify-test/tree/multiple-netlify-sites-yarn-v2)
- [npm](https://github.com/JGAntunes/gatsby-yarn-netlify-test/tree/multiple-netlify-sites)

An example output of a cached execution with `yarn`:
```sh
Finished restoring cached yarn cache
NETLIFY_YARN_WORKSPACES feature flag set
yarn workspaces v1.22.4
{
  "gatsby-starter-blog-1": {
    "location": "packages/blog-1",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": []
  },
  "gatsby-starter-blog-2": {
    "location": "packages/blog-2",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": []
  }
}
Done in 0.12s.
Started restoring workspace packages/blog-1 node modules
Finished restoring workspace packages/blog-1 node modules
Started restoring workspace packages/blog-2 node modules
Finished restoring workspace packages/blog-2 node modules
Started restoring workspace root node modules
Finished restoring workspace root node modules
Installing NPM modules using Yarn version 1.22.4
mkdir: cannot create directory ‘/opt/buildhome/tmp’: File exists
yarn install v1.22.4
[1/4] Resolving packages...
success Already up-to-date.
Done in 1.25s.
NPM modules installed using Yarn

(...)

Caching artifacts
Started saving workspace packages/blog-1 node modules
Finished saving workspace packages/blog-1 node modules
Started saving workspace packages/blog-2 node modules
Finished saving workspace packages/blog-2 node modules
Started saving workspace root node modules
Finished saving workspace root node modules
Started saving build plugins
Finished saving build plugins
Started saving yarn cache
Finished saving yarn cache
Started saving go dependencies
Finished saving go dependencies
```