### PR TITLE
syntax: bash launcher script hardening

### DIFF
--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -1,10 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-BASE_PATH=$(pwd)
-REPO_PATH=$(cd $1 && pwd)
+set -eu -o pipefail
+
+repo="${1-}"
+if [[ -z "$repo" ]]; then
+	>&2 echo "Usage: $0 <YOUR SITE REPO>"
+	exit 1
+fi
+
+BASE_PATH="$(pwd)"
+REPO_PATH="$(cd "$repo" && pwd)"
 : ${NETLIFY_IMAGE="netlify/build:xenial"}
 
-docker run --rm -t -i \
+exec docker run --rm -t -i \
 	-e NODE_VERSION \
 	-e NPM_VERSION \
 	-e RUBY_VERSION \
@@ -14,7 +22,7 @@ docker run --rm -t -i \
 	-e GO_VERSION \
 	-e SWIFT_VERSION \
 	-e PYTHON_VERSION \
-	-v ${REPO_PATH}:/opt/repo \
-	-v ${BASE_PATH}/run-build.sh:/opt/build-bin/build \
-	-v ${BASE_PATH}/run-build-functions.sh:/opt/build-bin/run-build-functions.sh \
-	$NETLIFY_IMAGE /bin/bash
+	-v "${REPO_PATH}":/opt/repo \
+	-v "${BASE_PATH}"/run-build.sh:/opt/build-bin/build \
+	-v "${BASE_PATH}"/run-build-functions.sh:/opt/build-bin/run-build-functions.sh \
+	"$NETLIFY_IMAGE" /bin/bash


### PR DESCRIPTION
Apply various hardening idioms to the default Bash launcher script:

- quote all variables
- quote all path names
- explicit error message on wrong usage
- use exec for the "wrapped" command
- use common hardening flags (this one is not technically useful in this script as it is, but it's a good idea anyway, in case it is ever modified with a statement that could benefit from it)
- use /usr/bin/env