### PR TITLE
fix: remove duplicated go import path code

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -891,6 +891,7 @@ set_go_import_path() {
     local dirPath="$(dirname $importPath)"
 
     rm -rf $importPath
+    mkdir -p $dirPath
     ln -s $PWD $importPath
 
     cd $importPath

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -898,8 +898,7 @@ set_go_import_path() {
     local importPath="$GOPATH/src/$GO_IMPORT_PATH"
     local dirPath="$(dirname $importPath)"
 
-    rm -rf $dirPath
-    mkdir -p $dirPath
+    rm -rf $importPath
     ln -s $PWD $importPath
 
     cd $importPath

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -690,14 +690,6 @@ install_dependencies() {
     restore_cwd_cache "target" "rust compile output"
     source $HOME/.cargo/env
   fi
-
-  # Setup project GOPATH
-  if [ -n "$GO_IMPORT_PATH" ]
-  then
-    mkdir -p "$(dirname $GOPATH/src/$GO_IMPORT_PATH)"
-    rm -rf $GOPATH/src/$GO_IMPORT_PATH
-    ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
-  fi
 }
 
 #


### PR DESCRIPTION
Removes duplicated code and no longer deletes siblings of the import path we're adding.