### PR TITLE
fix: Update homebrew install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -474,12 +474,14 @@ ENV PATH "$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 # Homebrew
 #
 ################################################################################
+USER root
+RUN mkdir -p /home/linuxbrew/.linuxbrew && chown -R buildbot /home/linuxbrew/
 USER buildbot
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/calavera/install/fc565dc04a2035287b90de7eab16933e59827734/install.sh)"
-ENV PATH "/opt/buildhome/.linuxbrew/bin:$PATH"
-ENV HOMEBREW_PREFIX "/opt/buildhome/.linuxbrew"
-ENV HOMEBREW_CELLAR "/opt/buildhome/.linuxbrew/Cellar"
-ENV HOMEBREW_REPOSITORY "/opt/buildhome/.linuxbrew/Homebrew"
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+ENV HOMEBREW_PREFIX "/home/linuxbrew/.linuxbrew"
+ENV PATH "${HOMEBREW_PREFIX}/bin:${PATH}"
+ENV HOMEBREW_CELLAR "${HOMEBREW_PREFIX}/Cellar"
+ENV HOMEBREW_REPOSITORY "${HOMEBREW_PREFIX}/Homebrew"
 ENV HOMEBREW_CACHE "/opt/buildhome/.homebrew-cache"
 RUN brew tap homebrew/bundle
 


### PR DESCRIPTION
The Dockerfile was using an old fork by David (former CTO) which installed a homebrew version that no longer worked.

I switched the Dockerfile to use the official script and swapped some things around to make it work.

i ran this to verify locally:
```
% docker build . -t netlify/build-image
% docker run -it --rm netlify/build-image bash
$ brew install capnp
```