### PR TITLE
chore: default php version to 5.6 in xenial

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -18,7 +18,7 @@ export GIMME_CGO_ENABLED=true
 export NVM_DIR="$HOME/.nvm"
 export RVM_DIR="$HOME/.rvm"
 
-#PHP configuration
+# PHP configuration
 DEFAULT_PHP_VERSION="5.6"
 
 # Swift configuration

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -18,6 +18,9 @@ export GIMME_CGO_ENABLED=true
 export NVM_DIR="$HOME/.nvm"
 export RVM_DIR="$HOME/.rvm"
 
+#PHP configuration
+DEFAULT_PHP_VERSION="5.6"
+
 # Swift configuration
 export SWIFTENV_ROOT="${SWIFTENV_ROOT:-${HOME}/.swiftenv}"
 DEFAULT_SWIFT_VERSION="5.2"
@@ -215,9 +218,8 @@ install_dependencies() {
   local defaultNodeVersion=$1
   local defaultRubyVersion=$2
   local defaultYarnVersion=$3
-  local defaultPHPVersion=$4
-  local installGoVersion=$5
-  local defaultPythonVersion=$6
+  local installGoVersion=$4
+  local defaultPythonVersion=$5
 
   # Python Version
   if [ -f runtime.txt ]
@@ -372,7 +374,7 @@ install_dependencies() {
   export JAVA_VERSION=default_sdk
 
   # PHP version
-  : ${PHP_VERSION="$defaultPHPVersion"}
+  : ${PHP_VERSION="$DEFAULT_PHP_VERSION"}
   if [ -f /usr/bin/php$PHP_VERSION ]
   then
     if ln -sf /usr/bin/php$PHP_VERSION $HOME/.php/php

--- a/run-build.sh
+++ b/run-build.sh
@@ -21,12 +21,11 @@ cd $NETLIFY_REPO_DIR
 : ${NODE_VERSION="12.18.0"}
 : ${RUBY_VERSION="2.7.1"}
 : ${YARN_VERSION="1.22.4"}
-: ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.14.4"}
 : ${PYTHON_VERSION="2.7"}
 
 echo "Installing dependencies"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $PYTHON_VERSION
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $GO_VERSION $PYTHON_VERSION
 
 echo "Installing missing commands"
 install_missing_commands


### PR DESCRIPTION
Currently, in buildbot, we don't actually check if there is a PHP version in the user's environment - we default to 5.6 for xenial. 
With us starting to [build both focal and xenial from the same main branch](https://github.com/netlify/buildbot/pull/1303#discussion_r622363195), we can move this default to the actual image.

This PR unblocks: https://github.com/netlify/buildbot/pull/1303 

