### PR TITLE
chore: default php version to 7.4 in Focal

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -23,7 +23,7 @@ export SWIFTENV_ROOT="${SWIFTENV_ROOT:-${HOME}/.swiftenv}"
 DEFAULT_SWIFT_VERSION="5.2"
 
 # PHP version
-DEFAULT_PHP_VERSION="5.2"
+DEFAULT_PHP_VERSION="7.4"
 
 # Pipenv configuration
 export PIPENV_RUNTIME=2.7

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -22,6 +22,9 @@ export RVM_DIR="$HOME/.rvm"
 export SWIFTENV_ROOT="${SWIFTENV_ROOT:-${HOME}/.swiftenv}"
 DEFAULT_SWIFT_VERSION="5.2"
 
+# PHP version
+DEFAULT_PHP_VERSION="5.2"
+
 # Pipenv configuration
 export PIPENV_RUNTIME=2.7
 export PIPENV_VENV_IN_PROJECT=1
@@ -215,9 +218,8 @@ install_dependencies() {
   local defaultNodeVersion=$1
   local defaultRubyVersion=$2
   local defaultYarnVersion=$3
-  local defaultPHPVersion=$4
-  local installGoVersion=$5
-  local defaultPythonVersion=$6
+  local installGoVersion=$4
+  local defaultPythonVersion=$5
 
   # Python Version
   if [ -f runtime.txt ]
@@ -372,7 +374,7 @@ install_dependencies() {
   export JAVA_VERSION=default_sdk
 
   # PHP version
-  : ${PHP_VERSION="$defaultPHPVersion"}
+  : ${PHP_VERSION="$DEFAULT_PHP_VERSION"}
   if [ -f /usr/bin/php$PHP_VERSION ]
   then
     if ln -sf /usr/bin/php$PHP_VERSION $HOME/.php/php

--- a/run-build.sh
+++ b/run-build.sh
@@ -21,12 +21,11 @@ cd $NETLIFY_REPO_DIR
 : ${NODE_VERSION="12.18.0"}
 : ${RUBY_VERSION="2.7.2"}
 : ${YARN_VERSION="1.22.4"}
-: ${PHP_VERSION="5.6"}
 : ${GO_VERSION="1.14.4"}
 : ${PYTHON_VERSION="2.7"}
 
 echo "Installing dependencies"
-install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $PHP_VERSION $GO_VERSION $PYTHON_VERSION
+install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $GO_VERSION $PYTHON_VERSION
 
 echo "Installing missing commands"
 install_missing_commands


### PR DESCRIPTION
Currently, in buildbot, we don't actually check if there is a PHP version in the user's environment - we default to 5.6 for xenial, but this is a version no longer supported in Focal (https://github.com/netlify/pod-workflow/issues/187).
With us starting to build both focal and xenial from the same main branch, we can move this default to the actual image.

This PR unblocks: netlify/buildbot#1303

