### PR TITLE
feat: Cache Clojure dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -350,6 +350,8 @@ RUN mkdir /opt/boot-clj && cd /opt/boot-clj && \
     chmod +x boot && \
     ln -s /opt/boot-clj/boot /usr/local/bin/boot
 
+# TODO: When upgrading to >= 1.10.1.672, also update approach for populating .m2 with clojure deps:
+# In run-build-functions.sh replace `clojure -Spath -Sforce >/dev/null` with more modern `clojure -P`
 RUN curl -sL https://download.clojure.org/install/linux-install-1.10.1.492.sh | bash
 
 USER buildbot

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -581,6 +581,12 @@ install_dependencies() {
     fi
   fi
 
+  # Clojure CLI
+  if [ -f deps.edn ]
+  then
+    restore_home_cache ".m2" "maven dependencies"
+  fi
+
   # Hugo
   if [ -n "$HUGO_VERSION" ]
   then

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -585,6 +585,7 @@ install_dependencies() {
   if [ -f deps.edn ]
   then
     restore_home_cache ".m2" "maven dependencies"
+    restore_home_cache ".gitlibs" "clojure git dependencies"
     restore_cwd_cache ".cpcache" "clojure classpath"
     echo "Installing Clojure dependencies"
     if clojure -Spath -Sforce >/dev/null
@@ -730,6 +731,7 @@ cache_artifacts() {
   cache_home_directory ".emacs.d" "emacs cache"
   cache_home_directory ".m2" "maven dependencies"
   cache_home_directory ".boot" "boot dependencies"
+  cache_home_directory ".gitlibs" "clojure git dependencies"
   cache_home_directory ".composer" "composer dependencies"
   cache_home_directory ".homebrew-cache", "homebrew cache"
   cache_home_directory ".rustup" "rust rustup cache"

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -585,6 +585,15 @@ install_dependencies() {
   if [ -f deps.edn ]
   then
     restore_home_cache ".m2" "maven dependencies"
+    restore_cwd_cache ".cpcache" "clojure classpath"
+    echo "Installing Clojure dependencies"
+    if clojure -Spath -Sforce >/dev/null
+    then
+      echo "Clojure dependencies installed"
+    else
+      echo "Error during Clojure install"
+      exit 1
+    fi
   fi
 
   # Hugo
@@ -706,6 +715,7 @@ cache_artifacts() {
 
   cache_cwd_directory ".venv" "python virtualenv"
   cache_cwd_directory ".build" "swift build"
+  cache_cwd_directory ".cpcache" "clojure classpath"
   cache_cwd_directory ".netlify/plugins" "build plugins"
   cache_cwd_directory ".netlify/rust-functions-cache" "Rust functions"
 


### PR DESCRIPTION
This PR adds caching for repos built with the [Clojure CLI tools][clojure-cli]. It extends 52f8eb9, which added initial support for building with the Clojure CLI tools, but did not address caching. It is similar to f3a4d49 which introduced caching for Leiningen and Boot, two other ways of building Clojure code.

This PR contains three commits. I'd like to see them all put into use, but the second one is certainly optional.

The first commit will significantly improve build times and decrease network bandwidth for Clojure repos. It does this by restoring the `.m2` directory before building, as other `JVM` based tools do.

The second commit is less important. It has two parts. 
* First, it takes advantage of a cache that the Clojure CLI tools create, a cache which helps them avoid re-calculating a JVM classpath. In practice, I haven't seen any projects where that calculation is so slow that this cache will have much impact. 
* Second, it downloads dependencies to the `.m2` directory before starting the build. Technically this is unnecessary. As opposed to a tool like, for example, `bundler`, which expects to resolve and download dependencies before the "real" code is run, the Clojure CLI tools combine dependency management and code execution into one step. Therefore existing builds that use the Clojure CLI tools already populate `.m2`. So, this change merely separates the steps, isolating errors that occur during download.

The third commit caches the `~/.gitlibs` directory, which the Clojure CLI tools use to cache dependencies [procured from git repos][git-procurement] (as opposed to from package managers). This will improve build times and decrease network bandwidth for Clojure repos which use this type of dependency procurement.

[clojure-cli]: https://clojure.org/reference/deps_and_cli
[git-procurement]: https://clojure.org/reference/deps_and_cli#_git