### PR TITLE
feat(node): change the default node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -292,7 +292,7 @@ RUN git clone https://github.com/creationix/nvm.git ~/.nvm && \
 ENV ELM_VERSION=0.19.0-bugfix6
 ENV YARN_VERSION=1.22.4
 
-ENV NETLIFY_NODE_VERSION="12.18.0"
+ENV NETLIFY_NODE_VERSION="14.16"
 
 RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
          nvm install --no-progress $NETLIFY_NODE_VERSION && \

--- a/run-build.sh
+++ b/run-build.sh
@@ -18,7 +18,7 @@ if [[ ! -d $NETLIFY_REPO_DIR ]]; then
 fi
 cd $NETLIFY_REPO_DIR
 
-: ${NODE_VERSION="12.18.0"}
+: ${NODE_VERSION="14.16"}
 : ${RUBY_VERSION="2.7.1"}
 : ${YARN_VERSION="1.22.4"}
 : ${PHP_VERSION="5.6"}


### PR DESCRIPTION
This is part of the work discussed in - https://github.com/netlify/pod-workflow/issues/180. We're also changing the current behaviour to only pin the major and minor version, so that new build-image builds always get the latest patches.

Setting this as draft for the time being while we settle some outstanding questions in https://github.com/netlify/pod-workflow/issues/180 and https://github.com/netlify/bitballoon/pull/9561