### PR TITLE
Fix: release php default update for focal

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@
            token: ${{ steps.get-token.outputs.token }}
            release-type: node
            package-name: "@netlify/build-image"
+           default-branch: focal


### PR DESCRIPTION
I accidentally merged the last commit as chore. we need this PR to cut a new release for focal.