### PR TITLE
fix: separate unlinking go import path from cache saving

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -743,13 +743,6 @@ cache_artifacts() {
     cache_home_directory ".cargo/bin" "rust cargo bin cache"
   fi
 
-  # Don't follow the Go import path or we'll store
-  # the origin repo twice.
-  if [ -n "$GO_IMPORT_PATH" ]
-  then
-    unlink $GOPATH/src/$GO_IMPORT_PATH
-  fi
-
   chmod -R +rw $HOME/.gimme_cache
   cache_home_directory ".gimme_cache" "go dependencies"
 
@@ -905,5 +898,12 @@ set_go_import_path() {
     ln -s $PWD $importPath
 
     cd $importPath
+  fi
+}
+
+unset_go_import_path() {
+  if [ -n "$GO_IMPORT_PATH" ]
+  then
+    unlink $GOPATH/src/$GO_IMPORT_PATH
   fi
 }


### PR DESCRIPTION
Related to https://github.com/netlify/buildbot/issues/534. Separates unlinking the go import path directory from the larger cache saving process. Will require a corresponding buildbot change.