### PR TITLE
chore: remove duplicated go import path code in Focal image

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -890,8 +890,7 @@ set_go_import_path() {
     local importPath="$GOPATH/src/$GO_IMPORT_PATH"
     local dirPath="$(dirname $importPath)"
 
-    rm -rf $dirPath
-    mkdir -p $dirPath
+    rm -rf $importPath
     ln -s $PWD $importPath
 
     cd $importPath

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -883,6 +883,7 @@ set_go_import_path() {
     local dirPath="$(dirname $importPath)"
 
     rm -rf $importPath
+    mkdir -p $dirPath
     ln -s $PWD $importPath
 
     cd $importPath

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -687,14 +687,6 @@ install_dependencies() {
     restore_cwd_cache "target" "rust compile output"
     source $HOME/.cargo/env
   fi
-
-  # Setup project GOPATH
-  if [ -n "$GO_IMPORT_PATH" ]
-  then
-    mkdir -p "$(dirname $GOPATH/src/$GO_IMPORT_PATH)"
-    rm -rf $GOPATH/src/$GO_IMPORT_PATH
-    ln -s /opt/buildhome/repo ${GOPATH}/src/$GO_IMPORT_PATH
-  fi
 }
 
 #


### PR DESCRIPTION
Duplicate of #545, but on Focal.