### PR TITLE
fix: separate go import path logic from cache saving for Focal image

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -733,13 +733,6 @@ cache_artifacts() {
     cache_home_directory ".cargo/bin" "rust cargo bin cache"
   fi
 
-  # Don't follow the Go import path or we'll store
-  # the origin repo twice.
-  if [ -n "$GO_IMPORT_PATH" ]
-  then
-    unlink $GOPATH/src/$GO_IMPORT_PATH
-  fi
-
   chmod -R +rw $HOME/.gimme_cache
   cache_home_directory ".gimme_cache" "go dependencies"
 
@@ -895,5 +888,12 @@ set_go_import_path() {
     ln -s $PWD $importPath
 
     cd $importPath
+  fi
+}
+
+unset_go_import_path() {
+  if [ -n "$GO_IMPORT_PATH" ]
+  then
+    unlink $GOPATH/src/$GO_IMPORT_PATH
   fi
 }


### PR DESCRIPTION
Duplicate of https://github.com/netlify/build-image/pull/560, but against the Focal image.