### PR TITLE
fix(workspace): don't log workspace detection errors from stderr

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -112,7 +112,7 @@ run_yarn() {
   local workspace_exit_code
   # YARN_IGNORE_PATH will ignore the presence of a local yarn executable (i.e. yarn 2) and default
   # to using the global one (which, for now, is always yarn 1.x). See https://yarnpkg.com/configuration/yarnrc#ignorePath
-  workspace_output="$(YARN_IGNORE_PATH=1 yarn workspaces --json info )"
+  workspace_output="$(YARN_IGNORE_PATH=1 yarn workspaces --json info 2>/dev/null)"
   workspace_exit_code=$?
   if [ $workspace_exit_code -eq 0 ]
   then


### PR DESCRIPTION
This PR addresses a issue with our current workspace detection where for `yarn` projects noy relying on workspaces the current command writes to `stderr`. See - https://app.netlify.com/sites/gatsby-yarn-test/deploys/60929032cc99e8127308c7a5#L80

Running the following on a non workspace directory renders:
```bash
$ YARN_IGNORE_PATH=1 yarn workspaces --json info
{"type":"error","data":"Cannot find the root of your workspace - are you sure you're currently in a workspace?"}
{"type":"info","data":"Visit \u001b[1mhttps://yarnpkg.com/en/docs/cli/workspaces\u001b[22m for documentation about this command."}

$ YARN_IGNORE_PATH=1 yarn workspaces --json info 2>/dev/null
{"type":"info","data":"Visit \u001b[1mhttps://yarnpkg.com/en/docs/cli/workspaces\u001b[22m for documentation about this command."}

$ TEST="$(YARN_IGNORE_PATH=1 yarn workspaces --json info)"
{"type":"error","data":"Cannot find the root of your workspace - are you sure you're currently in a workspace?"}

$ TEST="$(YARN_IGNORE_PATH=1 yarn workspaces --json info 2>/dev/null)"
$
```