### PR TITLE
fix: fix ruby version warnings and install iptables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         gtk-doc-tools \
         gnupg2 \
         imagemagick \
+        iptables \
         jpegoptim \
         jq \
         language-pack-ar \

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -320,12 +320,6 @@ install_dependencies() {
     export RUBY_VERSION=${crv#ruby-}
     echo "Using ruby version ${RUBY_VERSION}"
   else
-    echo -e "${YELLOW}"
-    echo "** WARNING **"
-    echo "Using custom ruby version ${druby}, this will slow down the build."
-    echo "To ensure fast builds, set the RUBY_VERSION environment variable, or .ruby-version file, to an included ruby version."
-    echo "Included versions: ${rvs[@]#ruby-}"
-    echo -e "${NC}"
     if rvm_install_on_use_flag=1 rvm --quiet-curl --create use ${druby}
     then
       local crv=$(rvm current)


### PR DESCRIPTION
As part of improving the experience with focal, we want to remove the WARN message when the ruby versions are different as:
* it's confusing for the user 
* it's the only one we alert on 
* it doesn't tell the customer how to fix it 

The tracking issue for ruby: https://github.com/netlify/bitballoon/issues/9481
The tracking issue for iptables: https://github.com/netlify/buildbot/issues/1419#issuecomment-861389905

xenial equivalent: https://github.com/netlify/bitballoon/issues/9481 

Tested with site: https://app.netlify.com/sites/elegant-heyrovsky-57fbb5/deploys/60c8f400150d65009ea17f8d