### PR TITLE
fix: replace gpg keyserver import for rvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,7 +228,7 @@ RUN adduser --system --disabled-password --uid 2500 --quiet buildbot --home /opt
 
 ## TODO: Consider switching to rbenv or asdf-vm
 USER buildbot
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - && curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import && \
     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
RVM is starting to fail in CI, this PR fixes it by changing the way we import the keys https://github.com/netlify/build-image/runs/3000193741 

```
 > [ 6/45] RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - &&     curl -sL https://get.rvm.io | bash -s stable --with-gems="bundler" --autolibs=read-fail:
#9 0.267 gpg: directory '/opt/buildhome/.gnupg' created
#9 0.267 gpg: keybox '/opt/buildhome/.gnupg/pubring.kbx' created
#9 0.350 gpg: key 3804BB82D39DC0E3: 47 signatures not checked due to missing keys
#9 0.352 gpg: /opt/buildhome/.gnupg/trustdb.gpg: trustdb created
#9 0.352 gpg: key 3804BB82D39DC0E3: public key "Michal Papis (RVM signing) <mpapis@gmail.com>" imported
#9 0.359 gpg: Total number processed: 1
#9 0.359 gpg:               imported: 1
#9 0.359 gpg: no ultimately trusted keys found
#9 1.810 Installing RVM with gems: bundler.
#9 3.199 Downloading https://github.com/rvm/rvm/archive/1.29.12.tar.gz
#9 5.054 Downloading https://github.com/rvm/rvm/releases/download/1.29.12/1.29.12.tar.gz.asc
#9 5.874 gpg: Signature made Fri 15 Jan 2021 06:46:22 PM UTC
#9 5.874 gpg:                using RSA key 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
#9 5.874 gpg: Can't check signature: No public key
#9 5.876 GPG signature verification failed for '/opt/buildhome/.rvm/archives/rvm-1.29.12.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.12/1.29.12.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:
#9 5.876
#9 5.876     gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
#9 5.876
#9 5.876 or if it fails:
#9 5.876
#9 5.876     command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
#9 5.876     command curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
#9 5.876
#9 5.876 In case of further problems with validation please refer to https://rvm.io/rvm/security
#9 5.876
```

inspiration: https://github.com/rvm/rvm/issues/4215 

sister PR: https://github.com/netlify/build-image/pull/584