### PR TITLE
feat: Install and default to PHP 8.0 (Focal)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     locale-gen en_US.UTF-8 && \
     update-locale en_US.UTF-8 && \
     apt-key adv --fetch-keys https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
+    add-apt-repository -y ppa:ondrej/php && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
     add-apt-repository -y ppa:git-core/ppa && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
@@ -144,6 +145,14 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         php7.4-curl \
         php7.4-zip \
         php7.4-intl \
+        php8.0 \
+        php8.0-xml \
+        php8.0-mbstring \
+        php8.0-gd \
+        php8.0-sqlite3 \
+        php8.0-curl \
+        php8.0-zip \
+        php8.0-intl \
         pngcrush \
         python-setuptools \
         python3.8-dev \
@@ -361,17 +370,17 @@ RUN curl -sL https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz | tar xzv
 
 USER root
 
-# set default to 7.4
-RUN update-alternatives --set php /usr/bin/php7.4 && \
-    update-alternatives --set phar /usr/bin/phar7.4 && \
-    update-alternatives --set phar.phar /usr/bin/phar.phar7.4
+# set default to 8.0
+RUN update-alternatives --set php /usr/bin/php8.0 && \
+    update-alternatives --set phar /usr/bin/phar8.0 && \
+    update-alternatives --set phar.phar /usr/bin/phar.phar8.0
 
 RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet && \
     mv composer.phar /usr/local/bin/composer
 
 USER buildbot
 
-RUN mkdir -p /opt/buildhome/.php && ln -s /usr/bin/php7.4 /opt/buildhome/.php/php
+RUN mkdir -p /opt/buildhome/.php && ln -s /usr/bin/php8.0 /opt/buildhome/.php/php
 ENV PATH "/opt/buildhome/.php:$PATH"
 
 ################################################################################

--- a/included_software.md
+++ b/included_software.md
@@ -19,7 +19,8 @@ The specific patch versions included will depend on when the image was last buil
   * 2.7 (default)
   * 3.8
 * PHP - `PHP_VERSION`
-  * 7.4 (default)
+  * 7.4
+  * 8.0 (default)
 * Go - `GO_VERSION`
   * 1.12 (default)
 * Java

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -23,7 +23,7 @@ export SWIFTENV_ROOT="${SWIFTENV_ROOT:-${HOME}/.swiftenv}"
 DEFAULT_SWIFT_VERSION="5.2"
 
 # PHP version
-DEFAULT_PHP_VERSION="7.4"
+DEFAULT_PHP_VERSION="8.0"
 
 # Pipenv configuration
 export PIPENV_RUNTIME=2.7


### PR DESCRIPTION
This PR is a follow-up to https://github.com/netlify/build-image/pull/588#issuecomment-877420397 – it installs PHP 8.0 in the Focal build image and sets it to be the default version.

PHP 8.0 is the current version of PHP and has been since November 2020, and as @ingride noted in #588, active support for PHP 7.4 will end at the end of November 2021. See https://www.php.net/supported-versions.php.

I'm not super familiar with Docker or with this build image, I think I updated `7.4` to `8.0` everywhere I needed to but I may have missed places. I was able to build the image locally, run it, open a shell inside the running container, and verify that PHP 8.0 is installed correctly and is the default version.

Let me know if there's anything else I can do here, and feel free to fold this into #588 directly if that's easier!