### PR TITLE
fix(yarn): make yarn install use the correct .yarn_cache path

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -146,7 +146,7 @@ run_yarn() {
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
 
-  if yarn install --cache-folder $NETLIFY_BUILD_BASE/.yarn_cache ${yarn_local:+"$yarn_local"}
+  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+"$yarn_local"}
   then
     echo "NPM modules installed using Yarn"
   else


### PR DESCRIPTION
The reciprocate of #595 for focal