### PR TITLE
fix: Make default Python and Go versions match doc in focal

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -21,8 +21,8 @@ cd $NETLIFY_REPO_DIR
 : ${NODE_VERSION="12.18.0"}
 : ${RUBY_VERSION="2.7.2"}
 : ${YARN_VERSION="1.22.4"}
-: ${GO_VERSION="1.14.4"}
-: ${PYTHON_VERSION="2.7"}
+: ${GO_VERSION="1.16.5"}
+: ${PYTHON_VERSION="3.9"}
 
 echo "Installing dependencies"
 install_dependencies $NODE_VERSION $RUBY_VERSION $YARN_VERSION $GO_VERSION $PYTHON_VERSION


### PR DESCRIPTION
In the `included_software.md` file it is claimed that the default
Python versions are 3.9 and 1.16 respectively. However, the run-build
script didn't match that.