### PR TITLE
chore(tests): add bats tests (xenial)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 tmp/
+node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker image
-        run: docker build . --build-arg NF_IMAGE_VERSION=$GITHUB_SHA -t netlify/build:$GITHUB_SHA
+        run: docker build . --build-arg NF_IMAGE_VERSION=$GITHUB_SHA  --target build-image -t netlify/build:$GITHUB_SHA
       - uses: vbrown608/whalescale@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -253,15 +253,14 @@ USER root
 
 RUN curl -o- -L https://yarnpkg.com/install.sh > /usr/local/bin/yarn-installer.sh
 
-
-
-USER buildbot
-
-# Install nvm and re-source our updated ~/.bash_profile
 ENV NVM_VERSION=0.35.3
-RUN curl -o- -L https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh > ~/install-nvm.sh && \
-    bash ~/install-nvm.sh && \
-    rm ~/install-nvm.sh
+
+# Install node.js
+USER buildbot
+RUN git clone https://github.com/creationix/nvm.git ~/.nvm && \
+    cd ~/.nvm && \
+    git checkout v$NVM_VERSION && \
+    cd /
 
 # Install node.js, yarn, bower and elm
 ENV ELM_VERSION=0.19.0-bugfix6
@@ -269,14 +268,11 @@ ENV YARN_VERSION=1.22.10
 
 ENV NETLIFY_NODE_VERSION="12.18.0"
 
-RUN /bin/bash -c "source ~/.nvm/nvm.sh && \
+RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
          nvm install --no-progress $NETLIFY_NODE_VERSION && \
          npm install -g sm grunt-cli bower elm@$ELM_VERSION && \
              bash /usr/local/bin/yarn-installer.sh --version $YARN_VERSION && \
          nvm alias default node && nvm cache clear"
-
-# Add yarn binary to path
-ENV PATH "$PATH:/opt/buildhome/.yarn/bin"
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -511,8 +511,12 @@ ENV NF_IMAGE_TAG ${NF_IMAGE_TAG:-latest}
 FROM build-image as build-image-test
 
 USER buildbot
+SHELL ["/bin/bash", "-c"]
+
 ADD --chown=buildbot package.json /opt/buildhome/test-env/package.json
-RUN /bin/bash -c "cd /opt/buildhome/test-env && . ~/.nvm/nvm.sh && npm i &&\
-                  ln -s /opt/build-bin/run-build-functions.sh /opt/buildhome/test-env/run-build-functions.sh &&\
-                  ln -s /opt/build-bin/build /opt/buildhome/test-env/run-build.sh"
+RUN cd /opt/buildhome/test-env && . ~/.nvm/nvm.sh && npm i &&\
+    ln -s /opt/build-bin/run-build-functions.sh /opt/buildhome/test-env/run-build-functions.sh &&\
+    ln -s /opt/build-bin/build /opt/buildhome/test-env/run-build.sh
 ADD --chown=buildbot tests /opt/buildhome/test-env/tests
+WORKDIR /opt/buildhome/test-env
+CMD . ~/.nvm/nvm.sh && npm test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty' ; buildingTag() }
       }
       steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} -t netlify/build:${env.BRANCH_NAME} -t netlify/build:${env.GIT_COMMIT} ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} -t netlify/build:${env.BRANCH_NAME} -t netlify/build:${env.GIT_COMMIT} --target build-image ."
       }
     }
 
@@ -25,7 +25,7 @@ pipeline {
         anyOf { buildingTag() }
       }
       steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} --squash -t netlify/build:${env.BRANCH_NAME}-squash ."
+        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} --squash -t netlify/build:${env.BRANCH_NAME}-squash --target build-image ."
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "This repository contains the tools to make the build image Netlify uses to build a site from git (for continuous deployment)",
   "main": "index.js",
   "private": "true",
-  "scripts": {},
+  "scripts": {
+    "test": "bats --recursive --timing --pretty tests"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/netlify/build-image.git"
@@ -15,5 +17,11 @@
     "url": "https://github.com/netlify/build-image/issues"
   },
   "homepage": "https://github.com/netlify/build-image#readme",
-  "devDependencies": {}
+  "devDependencies": {
+    "bats": "^1.3.0-alpha.0",
+    "bats-assert": "^2.0.0",
+    "bats-support": "^0.3.0",
+    "bats-file": "git+https://github.com/bats-core/bats-file.git#v0.3.0"
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": "true",
   "scripts": {
-    "test": "bats --recursive --timing --pretty tests"
+    "test": "bats --recursive --timing --tap tests"
   },
   "repository": {
     "type": "git",

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Clones a repo.
+#
+# Arguments:
+#   $1 - repo url
+#   $2 - path to clone into
+clone_repo() {
+  local url="$1"
+  local path="$2"
+  git clone --depth 1 ${url} ${path} >&3
+}
+
+
+# Setups a tmp dir to be used for test purposes.
+setup_tmp_dir() {
+  echo $(mktemp -d)
+}

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
-# Clones a repo.
-#
-# Arguments:
-#   $1 - repo url
-#   $2 - path to clone into
-clone_repo() {
-  local url="$1"
-  local path="$2"
-  git clone --depth 1 ${url} ${path} >&3
-}
+# Sets a given fixture as the project to be used as the target repository for our build-image scripts.
+# It expects a fixture name which should be present in a relative dir named `./fixtures` from the bats test executing it.
+# It sets the global `NETLIFY_BUILD_BASE`, `NETLIFY_CACHE_DIR` and `NETLIFY_REPO_DIR` variables based on the provided directory.
 
+# Arguments:
+#   $1 - fixture name
+#   $2 - path to use as the repo base (ideally a temporary dir)
+set_fixture_as_repo() {
+  local fixture="$1"
+  local tmp_dir="$2"
+  NETLIFY_BUILD_BASE=$tmp_dir
+  NETLIFY_CACHE_DIR="$NETLIFY_BUILD_BASE/cache"
+  NETLIFY_REPO_DIR="$NETLIFY_BUILD_BASE/repo"
+  rm -rf "$NETLIFY_REPO_DIR"
+  cp -r "$BATS_TEST_DIRNAME/fixtures/$fixture" "$NETLIFY_REPO_DIR"
+
+  # Change to the repo dir
+  cd "$NETLIFY_REPO_DIR" || exit 1
+}
 
 # Setups a tmp dir to be used for test purposes.
 setup_tmp_dir() {
-  echo $(mktemp -d)
+  mktemp -d
 }

--- a/tests/node/base.bats
+++ b/tests/node/base.bats
@@ -8,6 +8,8 @@ load '../../node_modules/bats-assert/load'
 
 NODE_VERSION=12.18.0
 
+#Note: These binaries are accessible because we source `~/.nvm/nvm.sh` before running the `bats` tests
+
 @test 'node version ${NODE_VERSION} is installed and available at startup' {
   run node --version
   assert_success

--- a/tests/node/base.bats
+++ b/tests/node/base.bats
@@ -7,18 +7,11 @@ load '../../node_modules/bats-assert/load'
 
 
 NODE_VERSION=12.18.0
-YARN_VERSION=1.22.4
 
 @test 'node version ${NODE_VERSION} is installed and available at startup' {
   run node --version
   assert_success
   assert_output --partial $NODE_VERSION
-}
-
-@test 'yarn version ${YARN_VERSION} is installed and available at startup' {
-  run yarn --version
-  assert_success
-  assert_output --partial $YARN_VERSION
 }
 
 @test 'grunt-cli is installed and available at startup' {

--- a/tests/node/base.bats
+++ b/tests/node/base.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load "../helpers.sh"
+
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
+
+
+NODE_VERSION=12.18.0
+YARN_VERSION=1.22.4
+
+@test 'node version ${NODE_VERSION} is installed and available at startup' {
+  run node --version
+  assert_success
+  assert_output --partial $NODE_VERSION
+}
+
+@test 'yarn version ${YARN_VERSION} is installed and available at startup' {
+  run yarn --version
+  assert_success
+  assert_output --partial $YARN_VERSION
+}
+
+@test 'grunt-cli is installed and available at startup' {
+  run grunt --version
+  assert_success
+}
+
+@test 'bower is installed and available at startup' {
+  run bower --version
+  assert_success
+}

--- a/tests/node/fixtures/simple-node/package.json
+++ b/tests/node/fixtures/simple-node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "simple-node-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@netlify/plugins-list": "^3.6.0"
+  }
+}

--- a/tests/node/yarn.bats
+++ b/tests/node/yarn.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+load "../helpers.sh"
+
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
+load '../../node_modules/bats-file/load'
+
+YARN_CACHE_DIR=/opt/buildhome/.yarn_cache
+NEW_YARN_VERSION=1.21.0
+
+setup() {
+  # Make sure the cache dir is clear
+  rm -rf '/opt/buildhome/.yarn_cache'
+
+  TMP_DIR=$(setup_tmp_dir)
+  REPO_DIR="$TMP_DIR/netlify-cms"
+  clone_repo https://github.com/netlify/netlify-cms.git $REPO_DIR
+
+  # Load functions
+  load '../../run-build-functions.sh'
+
+  # Change to the repo dir
+  cd $REPO_DIR
+}
+
+teardown() {
+  rm -rf $TMP_DIR
+  # Return to original dir
+  cd -
+}
+
+@test 'run_yarn setups new yarn version, installs deps and creates cache dir' {
+  run run_yarn $NEW_YARN_VERSION
+  assert_success
+  assert_output --partial "doesn't match expected ($NEW_YARN_VERSION)"
+  assert_dir_exist $YARN_CACHE_DIR
+}

--- a/tests/node/yarn.bats
+++ b/tests/node/yarn.bats
@@ -7,32 +7,28 @@ load '../../node_modules/bats-assert/load'
 load '../../node_modules/bats-file/load'
 
 YARN_CACHE_DIR=/opt/buildhome/.yarn_cache
-NEW_YARN_VERSION=1.21.0
 
 setup() {
-  # Make sure the cache dir is clear
-  rm -rf '/opt/buildhome/.yarn_cache'
-
   TMP_DIR=$(setup_tmp_dir)
-  REPO_DIR="$TMP_DIR/netlify-cms"
-  clone_repo https://github.com/netlify/netlify-cms.git $REPO_DIR
+  set_fixture_as_repo 'simple-node' "$TMP_DIR"
 
   # Load functions
   load '../../run-build-functions.sh'
-
-  # Change to the repo dir
-  cd $REPO_DIR
 }
 
 teardown() {
-  rm -rf $TMP_DIR
+  rm -rf "$TMP_DIR"
   # Return to original dir
-  cd -
+  cd - || return
 }
 
-@test 'run_yarn setups new yarn version, installs deps and creates cache dir' {
-  run run_yarn $NEW_YARN_VERSION
+@test 'run_yarn sets up new yarn version if different from the one installed, installs deps and creates cache dir' {
+  local newYarnVersion=1.21.0
+  run run_yarn $newYarnVersion
   assert_success
-  assert_output --partial "doesn't match expected ($NEW_YARN_VERSION)"
+  assert_output --partial "Installing yarn at version $newYarnVersion"
   assert_dir_exist $YARN_CACHE_DIR
+
+  # The cache dir is actually being used
+  assert_dir_exist "$YARN_CACHE_DIR/v6"
 }


### PR DESCRIPTION
## Overview

Part of https://github.com/netlify/pod-workflow/issues/137, the idea is to add a set of [bats tests](https://github.com/bats-core/bats-core) with the proposed structure.

```sh
tests/
├─ node/
│  ├─ base.bats
│  ├─ yarn.bats
│  ├─ fixtures/
├─ ruby/
│  ├─ base.bats
│  ├─ fixtures/
├─ <some-other-tool-or-runtime>/
├─ helpers.sh
├─ some-generic-global-tests.bats
├─ fixtures/
```

This is far from set in stone FYI 😅 open to ideas. We can also revisit this as we add more tests and see the need for a different re-org.

Out of scope for this PR are:
- Documentation
- Integration with our CI system.
☝️ to be addressed in follow up PRs.

**Important:** With the addition of an extra stage for our dockerfile, any `docker build` execution aiming at having a prod ready image needs to `--target build-image` specifically (hence all the chaneges to the `Jenkinsfile` and `.workflows`.

## Execution

Currently, these can be executed via:
```sh
docker build -t build-image-xenial-with-tests .
docker run --rm build-image-xenial-with-tests
```

Rendering the following:
```sh
> @netlify/build-image@3.9.0 test /opt/buildhome/test-env
> bats --recursive --timing --tap tests

1..4
ok 1 node version 12.18.0 is installed and available at startup in 18ms
ok 2 grunt-cli is installed and available at startup in 416ms
ok 3 bower is installed and available at startup in 761ms
ok 4 run_yarn sets up new yarn version if different from the one installed, installs deps and creates cache dir in 11007ms
```

Failing assertions produce something like:
```sh
1..4
not ok 1 node version 12.18.1 is installed and available at startup in 71ms
# (from function `assert_output' in file tests/node/../../node_modules/bats-assert/src/assert.bash, line 247,
#  in test file tests/node/base.bats, line 16)
#   `assert_output --partial $NODE_VERSION' failed
#
# -- output does not contain substring --
# substring : 12.18.1
# output    : v12.18.0
# --
#
ok 2 grunt-cli is installed and available at startup in 466ms
ok 3 bower is installed and available at startup in 743ms
ok 4 run_yarn sets up new yarn version if different from the one installed, installs deps and creates cache dir in 9463ms
npm ERR! Test failed.  See above for more details.
```

We could probably benefit from scripts that volumed both the  `tests` dir as well as the `run-build*` scripts in order to provide a better dev ex. IMO we could tackle that afterwards (e.g. as part of the documentation work).