### PR TITLE
fix: YARN_FLAGS doesn't handle more than one flag

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -149,7 +149,7 @@ run_yarn() {
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
 
-  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+"$yarn_local"}
+  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+$yarn_local}
   then
     echo "NPM modules installed using Yarn"
   else


### PR DESCRIPTION
The issue was opened by myself [in the Netlify community forums](https://answers.netlify.com/t/yarn-flags-env-variable-being-ignored/33637/12)
This fix is based on [a very similar fix for NPM_FLAGS](https://github.com/netlify/build-image/pull/574)