### PR TITLE
fix: make Puppeteer work on Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libexif-dev \
         libffi-dev \
         libfontconfig1 \
+        libgbm-dev \
         libgconf-2-4 \
         libgd-dev \
         libgdbm-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libexif-dev \
         libffi-dev \
         libfontconfig1 \
-        libgbm-dev \
+        libgbm1 \
         libgconf-2-4 \
         libgd-dev \
         libgdbm-dev \


### PR DESCRIPTION
This fixes Puppeteer not working on Focal. 
As a consequence, this also fixes `netlify-plugin-lighthouse` and `netlify-plugin-cypress` not working on Focal: https://github.com/netlify-labs/netlify-plugin-lighthouse/issues/271 and https://github.com/netlify/pod-workflow/issues/277

Missing `libgbm-dev` [is the problem](https://github.com/actions/virtual-environments/issues/732#issuecomment-614809415) (see also [this](https://github.com/puppeteer/puppeteer/blob/46ef9f79caa49e5a64d235e6e4247ebdf1b7cc2d/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix)).

Manual testing: [with the fix](https://app.netlify.com/sites/mick/deploys/61423555a71cbd000895a15b#L442), [without the fix](https://app.netlify.com/sites/mick/deploys/6142393d353eae1f904c3068#L423).

Build image size change: 0.064% smaller.