### PR TITLE
chore: fix dead link in release doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 1. Merge the relevant package release PR created by `release-please`
 2. Wait for the Jenkins build to finish
-3. Create a PR in the [buildbot](https://github.com/netlify/buildbot) to bump [the version](https://github.com/netlify/buildbot/blob/a247edab7ead955cc27bb70ecc9f081e68f1aea6/script/docker-build.sh#L17) of the `build-image`.
+3. Create a PR in the [buildbot](https://github.com/netlify/buildbot) to bump [the version](https://github.com/netlify/buildbot/blob/ddbb47739f5b85c954aad9dc3823ab0676432957/Jenkinsfile#L35) of the `build-image`.
 
 ## License
 


### PR DESCRIPTION
Some link is outdated. This PR fixes it.