### PR TITLE
docs: Specify minimum Ruby version supported on Focal

### DIFF
--- a/included_software.md
+++ b/included_software.md
@@ -11,7 +11,7 @@ The specific patch versions included will depend on when the image was last buil
 * Ruby - `RUBY_VERSION`, `.ruby-version`
   * 2.7.2 (default)
   * 2.6.6
-  * Any version that `rvm` can install.
+  * Any version >= 2.4.0 that `rvm` can install.
 * Node.js - `NODE_VERSION`, `.nvmrc`, `.node-version`
   * 16 (default)
   * Any version that `nvm` can install.

--- a/included_software.md
+++ b/included_software.md
@@ -11,7 +11,7 @@ The specific patch versions included will depend on when the image was last buil
 * Ruby - `RUBY_VERSION`, `.ruby-version`
   * 2.7.2 (default)
   * 2.6.6
-  * Any version >= 2.4.0 that `rvm` can install.
+  * Any version 2.4.0 or later that `rvm` can install.
 * Node.js - `NODE_VERSION`, `.nvmrc`, `.node-version`
   * 16 (default)
   * Any version that `nvm` can install.


### PR DESCRIPTION
Our toolchain on Focal doesn't support versions of Ruby older than 2.4.0. This updates the included software doc to reflect that minimum when describing which versions can be installed via `rvm`.

Adding @KyleBlankRollins for writing review. I opted for `<=` for brevity, but perhaps we should use human language instead?