### PR TITLE
fix: multiple yarn flags

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -149,7 +149,7 @@ run_yarn() {
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
 
-  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+$yarn_local}
+  if yarn install --cache-folder "$HOME/.yarn_cache" ${yarn_local:+$yarn_local}
   then
     echo "NPM modules installed using Yarn"
   else

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -149,7 +149,7 @@ run_yarn() {
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
 
-  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+"$yarn_local"}
+  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+$yarn_local}
   then
     echo "NPM modules installed using Yarn"
   else


### PR DESCRIPTION
This is a follow up of https://github.com/netlify/build-image/pull/620, based on @Robin-Hoodie's awesome contribution.

Added tests for a couple of `YARN_FLAGS` scenarios. Given these aren't still integrated in our CI here's the output:

```bash
$ make test
(...)
1..6
ok 1 node version  is installed and available at startup in 2232ms
ok 2 grunt-cli is installed and available at startup in 2605ms
ok 3 bower is installed and available at startup in 2891ms
ok 4 run_yarn sets up new yarn version if different from the one installed, installs deps and creates cache dir in 9213ms
ok 5 run_yarn allows passing multiple yarn flags via YARN_FLAGS env var to yarn install in 7761ms
ok 6 run_yarn does not allow setting --cache-folder via YARN_FLAGS in 5967ms
```