### PR TITLE
fix: multiple yarn flags xenial

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -149,7 +149,7 @@ run_yarn() {
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
 
-  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+$yarn_local}
+  if yarn install --cache-folder "$HOME/.yarn_cache" ${yarn_local:+$yarn_local}
   then
     echo "NPM modules installed using Yarn"
   else

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -149,7 +149,7 @@ run_yarn() {
   # This removes the flag from the end of the string.
   yarn_local="${yarn_local%--cache-folder *}"
 
-  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+"$yarn_local"}
+  if yarn install --cache-folder $HOME/.yarn_cache ${yarn_local:+$yarn_local}
   then
     echo "NPM modules installed using Yarn"
   else


### PR DESCRIPTION
Backport PR for Xenial. This PR fixes support for multiple yarn flags via the `YARN_FLAGS` env var. Related with - #642 and #620