### PR TITLE
chore(ci-release-please): set default branch to xenial

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@
            token: ${{ steps.get-token.outputs.token }}
            release-type: node
            package-name: "@netlify/build-image"
+           default-branch: xenial


### PR DESCRIPTION
This is required since the default branch for this repo was changed to `focal`