### PR TITLE
docs: remove Trusty included-software link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Netlify maintains multiple build images for testing new development as well as s
 
 The following images are currently available:
 
-- `trusty` - Legacy build image for older sites; running Ubuntu 14.04 and [this software](https://github.com/netlify/build-image/blob/trusty/included_software.md)
-- `xenial` - Build image for existing sites; running Ubuntu 16.04 and [this software](https://github.com/netlify/build-image/blob/xenial/included_software.md)
 - `focal` - Default build image for all new sites; Running Ubuntu 20.04 and [this software](https://github.com/netlify/build-image/blob/focal/included_software.md)
+- `xenial` - Build image for existing sites; running Ubuntu 16.04 and [this software](https://github.com/netlify/build-image/blob/xenial/included_software.md)
 
 Each image name above corresponds to a branch in this repository.
 


### PR DESCRIPTION
Just notice that we still link to the Trusty included-software list, so I removed it. I also moved Focal to the top, since it's the default.

We'll also want to copy this change to Xenial. Should I make a separate PR, or shall we just cherry pick it over?

![A tahr on a hill. Similar to a goat with long hair like a lion's mane](https://upload.wikimedia.org/wikipedia/commons/0/02/Hemitragus_jemlahicus_Jharal.jpg)
_A very majestic (and probably trusty) tahr_