### PR TITLE
docs: remove Trusty from Xenial included-software links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Netlify maintains multiple build images for testing new development as well as s
 
 The following images are currently available:
 
-- `trusty` - Legacy build image for older sites; running Ubuntu 14.04 and [this software](https://github.com/netlify/build-image/blob/trusty/included_software.md)
-- `xenial` - Build image for all existing sites; running Ubuntu 16.04 and [this software](https://github.com/netlify/build-image/blob/xenial/included_software.md)
-- `focal`  - Default build image for all new sites; Running Ubuntu 20.04 and [this software](https://github.com/netlify/build-image/blob/focal/included_software.md)
+- `xenial` (current branch) - Legacy build image for existing sites; running Ubuntu 16.04 and [this software](https://github.com/netlify/build-image/blob/xenial/included_software.md)
+- `focal` - Default build image for all new sites; running Ubuntu 20.04 and [this software](https://github.com/netlify/build-image/blob/focal/included_software.md)
 
 Each image name above corresponds to a branch in this repository.
 


### PR DESCRIPTION
Roughly a duplicate of https://github.com/netlify/build-image/pull/647 (for Focal)

I added a parenthetical to note that the readme is on the xenial branch, and didn't re-order the images.

![another tahr](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Himalaja-Tahr.JPG/1024px-Himalaja-Tahr.JPG)