### PR TITLE
fix: add buildbot group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,7 +207,7 @@ RUN wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-
 #
 ################################################################################
 
-RUN adduser --system --disabled-password --uid 2500 --quiet buildbot --home /opt/buildhome
+RUN adduser --system --disabled-password --uid 2500 --group --quiet buildbot --home /opt/buildhome
 
 ################################################################################
 #
@@ -484,7 +484,7 @@ FROM build-image as build-image-test
 USER buildbot
 SHELL ["/bin/bash", "-c"]
 
-ADD --chown=buildbot:root package.json /opt/buildhome/test-env/package.json
+ADD --chown=buildbot:buildbot package.json /opt/buildhome/test-env/package.json
 
 # We need to install with `--legacy-peer-deps` because of:
 # https://github.com/bats-core/bats-assert/issues/27
@@ -492,7 +492,7 @@ RUN cd /opt/buildhome/test-env && . ~/.nvm/nvm.sh && npm i --legacy-peer-deps &&
     ln -s /opt/build-bin/run-build-functions.sh /opt/buildhome/test-env/run-build-functions.sh &&\
     ln -s /opt/build-bin/build /opt/buildhome/test-env/run-build.sh
 
-ADD --chown=buildbot:root tests /opt/buildhome/test-env/tests
+ADD --chown=buildbot:buildbot tests /opt/buildhome/test-env/tests
 WORKDIR /opt/buildhome/test-env
 
 # Set `bats` as entrypoint

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load "./helpers.sh"
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+@test '/opt/buildhome folder owner and group is buildbot' {
+  local owner=$(stat -c '%U:%G' /opt/buildhome)
+  assert_equal $owner "buildbot:buildbot"
+}


### PR DESCRIPTION
This is a follow up from  #651, coming from this specific comment https://github.com/netlify/build-image/pull/651#discussion_r729879144.

Our current `adduser` command creates the `buildbot` user but no associated group to it:
https://github.com/netlify/build-image/blob/e074d684739d8ed6a6d5e679d2891a3ef0dbdfd6/Dockerfile#L210

Our resulting `home` folder (`/opt/buildhome`) ends up having a series of files under `nogroup`:
```
buildbot@9b62b78af2e3:/$ ls -la /opt/buildhome/
total 128
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:26 .
drwxr-xr-x  1 root     root    4096 Oct  4 11:26 ..
-rw-r--r--  1 buildbot nogroup  221 Oct  4 11:26 .bash_profile
-rw-r--r--  1 buildbot nogroup  139 Oct  4 11:26 .bashrc
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:22 .binrc
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:22 .boot
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:22 .cache
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:26 .cargo
drwxr-xr-x 10 buildbot nogroup 4096 Oct  4 11:22 .cask
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:22 .dotnet
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:21 .gem
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:22 .gimme
drwx------  1 buildbot nogroup 4096 Oct  4 11:21 .gnupg
drwxr-xr-x  2 buildbot nogroup 4096 Oct  4 11:26 .homebrew-cache
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:22 .lein
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:21 .local
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:22 .m2
-rw-r--r--  1 buildbot nogroup  118 Oct  4 11:20 .mkshrc
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:21 .npm
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:21 .nvm
drwxr-xr-x  2 buildbot nogroup 4096 Oct  4 11:22 .php
-rw-r--r--  1 buildbot nogroup  338 Oct  4 11:26 .profile
drwxr-xr-x  4 buildbot nogroup 4096 Oct  4 11:21 python2.7
lrwxrwxrwx  1 buildbot nogroup   24 Oct  4 11:21 python2.7.18 -> /opt/buildhome/python2.7
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:21 python3.8
lrwxrwxrwx  1 buildbot nogroup   24 Oct  4 11:21 python3.8.10 -> /opt/buildhome/python3.8
drwxr-xr-x  2 buildbot nogroup 4096 Oct  4 11:26 .rustup
drwxr-xr-x  1 buildbot nogroup 4096 Oct  4 11:20 .rvm
-rw-r--r--  1 buildbot nogroup   25 Oct  4 11:20 .rvmrc
drwxr-xr-x 11 buildbot nogroup 4096 Oct  4 11:22 .swiftenv
drwxr-xr-x  3 buildbot nogroup 4096 Oct  4 11:22 .templateengine
drwxr-xr-x  4 buildbot nogroup 4096 Oct  4 11:21 .yarn
-rw-r--r--  1 buildbot nogroup  118 Oct  4 11:20 .zlogin
-rw-r--r--  1 buildbot nogroup  118 Oct  4 11:20 .zshrc
```

Which isn't ideal as per:
- https://wiki.debian.org/SystemGroups
- https://unix.stackexchange.com/questions/186568/what-is-nobody-user-and-group

~~Opening as a draft as I want to add some automated tests to this 👍~~ 

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] ~~Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures
      we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.~~ - this is a follow up from a PR
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] ~~Update the [included software doc](../included_software.md) (if you updated included software) 📄~~
- [ ] ~~Update or add documentation (if features were changed or added) 📝~~
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
