### PR TITLE
chore(cci): move from env vars to contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,7 @@ workflows:
           type: approval
           requires: [build-images-for-forks]
       - push-to-registry:
+          context: test-build-image
           container-image: "jgantunesntf/netlify-build"
           requires: [hold-push-to-registry]
       - run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,18 +247,20 @@ workflows:
             branches:
               ignore: /.*/
           name: build-and-push-git-tag-squash-image
+          context: test-build-image
           container-image: "jgantunesntf/netlify-build"
           squash-images: true
           build-test-image: false
           save-images-in-workflow: false
       # For git tags we still want to build and push non squashed images
       - build-and-push-images:
-          name: build-and-push-git-tag-image
           filters:
             tags:
               only: /^v.*/
             branches:
               ignore: /.*/
+          name: build-and-push-git-tag-image
+          context: test-build-image
           container-image: "jgantunesntf/netlify-build"
           build-test-image: false
           save-images-in-workflow: false
@@ -274,6 +276,7 @@ workflows:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
+          context: test-build-image
           container-image: "jgantunesntf/netlify-build"
           build-test-image: true
           save-images-in-workflow: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ workflows:
             branches:
               ignore: /.*/
           name: build-and-push-git-tag-squash-image
-          context: test-build-image
+          context: build-image-registry
           container-image: "jgantunesntf/netlify-build"
           squash-images: true
           build-test-image: false
@@ -260,7 +260,7 @@ workflows:
             branches:
               ignore: /.*/
           name: build-and-push-git-tag-image
-          context: test-build-image
+          context: build-image-registry
           container-image: "jgantunesntf/netlify-build"
           build-test-image: false
           save-images-in-workflow: false
@@ -276,7 +276,7 @@ workflows:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
-          context: test-build-image
+          context: build-image-registry
           container-image: "jgantunesntf/netlify-build"
           build-test-image: true
           save-images-in-workflow: true
@@ -296,7 +296,7 @@ workflows:
           type: approval
           requires: [build-images-for-forks]
       - push-to-registry:
-          context: test-build-image
+          context: build-image-registry
           container-image: "jgantunesntf/netlify-build"
           requires: [hold-push-to-registry]
       - run-tests:


### PR DESCRIPTION
#### Summary

Related with https://github.com/netlify/pod-workflow/issues/251. We're moving from using environment variables within the project, to `context` entries with the required secrets that are only allowed to execute if the job is either from a trusted source or authorised by a trusted source via a manual approval step - https://circleci.com/docs/2.0/contexts/#running-workflows-with-a-restricted-context

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

🐶 