### PR TITLE
chore(ci): drop Jenkins and move to the correct docker repo (xenial)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ workflows:
               ignore: /.*/
           name: build-and-push-git-tag-squash-image
           context: build-image-registry
-          container-image: "jgantunesntf/netlify-build"
+          container-image: "netlify/build"
           squash-images: true
           build-test-image: false
           save-images-in-workflow: false
@@ -261,7 +261,7 @@ workflows:
               ignore: /.*/
           name: build-and-push-git-tag-image
           context: build-image-registry
-          container-image: "jgantunesntf/netlify-build"
+          container-image: "netlify/build"
           build-test-image: false
           save-images-in-workflow: false
 
@@ -277,7 +277,7 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
           context: build-image-registry
-          container-image: "jgantunesntf/netlify-build"
+          container-image: "netlify/build"
           build-test-image: true
           save-images-in-workflow: true
       # If building from forked repos we don't push the images directly,
@@ -288,7 +288,7 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               only: /pull\/[0-9]+/
           name: build-images-for-forks
-          container-image: "jgantunesntf/netlify-build"
+          container-image: "netlify/build"
           build-test-image: true
           save-images-in-workflow: true
           push-images: false
@@ -297,8 +297,8 @@ workflows:
           requires: [build-images-for-forks]
       - push-to-registry:
           context: build-image-registry
-          container-image: "jgantunesntf/netlify-build"
+          container-image: "netlify/build"
           requires: [hold-push-to-registry]
       - run-tests:
-          container-image: "jgantunesntf/netlify-build"
+          container-image: "netlify/build"
           requires: [build-and-push-images, build-images-for-forks, lint]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,72 +2,78 @@ pipeline {
   agent any
 
   stages {
-    stage("Test Build") {
-      when {
-        not { anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty  ' ; buildingTag() } }
-      }
+    stage("skip") {
       steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} ."
+        sh 'echo "skipping in favor of CircleCI build"'
       }
     }
 
-    stage("Build Tags and Special Branches") {
-      when {
-        anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty' ; buildingTag() }
-      }
-      steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} -t netlify/build:${env.BRANCH_NAME} -t netlify/build:${env.GIT_COMMIT} --target build-image ."
-      }
-    }
-
-    stage("Build Squash images") {
-      when {
-        anyOf { buildingTag() }
-      }
-      steps {
-        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} --squash -t netlify/build:${env.BRANCH_NAME}-squash --target build-image ."
-      }
-    }
-
-    stage("Push Images") {
-      when {
-        anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty' ; buildingTag()}
-      }
-      steps {
-        script {
-          docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
-            docker.image("netlify/build:${env.BRANCH_NAME}").push()
-            docker.image("netlify/build:${env.GIT_COMMIT}").push()
-            if (env.BRANCH_NAME == 'xenial') {
-              docker.image("netlify/build:${env.BRANCH_NAME}").push('latest')
-            }
-          }
-        }
-      }
-    }
-
-    stage("Push Squash Images") {
-      when {
-        anyOf { buildingTag() }
-      }
-      steps {
-        script {
-          docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
-            docker.image("netlify/build:${env.BRANCH_NAME}-squash").push()
-          }
-        }
-      }
-    }
-  }
-
-  post {
-    failure {
-      slackSend color: "danger", message: "Build failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}/console|Open>)"
-    }
-    success {
-      slackSend color: "good", message: "Build succeeded - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}/console|Open>)"
-    }
-  }
+//    stage("Test Build") {
+//      when {
+//        not { anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty' ; branch 'focal' ; buildingTag() } }
+//      }
+//      steps {
+//        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} ."
+//      }
+//    }
+//
+//    stage("Build Tags and Special Branches") {
+//      when {
+//        anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty' ; branch 'focal' ; buildingTag() }
+//      }
+//      steps {
+//        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} -t netlify/build:${env.BRANCH_NAME} -t netlify/build:${env.GIT_COMMIT} --target build-image ."
+//      }
+//    }
+//
+//    stage("Build Squash images") {
+//      when {
+//        anyOf { buildingTag() }
+//      }
+//      steps {
+//        sh "docker build --build-arg NF_IMAGE_VERSION=${env.GIT_COMMIT} --build-arg NF_IMAGE_TAG=${env.BRANCH_NAME} --squash -t netlify/build:${env.BRANCH_NAME}-squash --target build-image ."
+//      }
+//    }
+//
+//    stage("Push Images") {
+//      when {
+//        anyOf { branch 'staging' ; branch 'xenial' ; branch 'trusty' ; branch 'focal' ; buildingTag()}
+//      }
+//      steps {
+//        script {
+//          docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
+//            docker.image("netlify/build:${env.BRANCH_NAME}").push()
+//            docker.image("netlify/build:${env.GIT_COMMIT}").push()
+//            if (env.BRANCH_NAME == 'xenial') {
+//              docker.image("netlify/build:${env.BRANCH_NAME}").push('latest')
+//            }
+//          }
+//        }
+//      }
+//    }
+//
+//    stage("Push Squash Images") {
+//      when {
+//        anyOf { buildingTag() }
+//      }
+//      steps {
+//        script {
+//          docker.withRegistry('https://index.docker.io/v1/', 'docker-hub-ci') {
+//            docker.image("netlify/build:${env.BRANCH_NAME}-squash").push()
+//          }
+//        }
+//      }
+//    }
+//  }
+//
+//  post {
+//    failure {
+//      slackSend color: "danger", message: "Build failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}/console|Open>)"
+//    }
+//    success {
+//      slackSend color: "good", message: "Build succeeded - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}/console|Open>)"
+//    }
+//  }
 }
 
 /*


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Same as #668 but for the `xenial` branch. Related with netlify/pod-workflow#251 this PR comments out our Jenkinsfile and starts pushing images from circle ci to our docker repo.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

🦋 