### PR TITLE
feat: add build-image codename env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -466,11 +466,17 @@ ADD buildbot-git-config /root/.gitconfig
 RUN rm -r /tmp/*
 
 USER buildbot
+# The semver version associated with this build (i.e. v3.0.0)
 ARG NF_IMAGE_VERSION
 ENV NF_IMAGE_VERSION ${NF_IMAGE_VERSION:-latest}
 
+# The commit SHA tag associated with this build
 ARG NF_IMAGE_TAG
 ENV NF_IMAGE_TAG ${NF_IMAGE_TAG:-latest}
+
+# The codename associated with this build (i.e. focal)
+ARG NF_IMAGE_NAME
+ENV NF_IMAGE_NAME ${NF_IMAGE_NAME:-focal}
 
 
 ################################################################################

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -9,3 +9,15 @@ load '../node_modules/bats-assert/load'
   local owner=$(stat -c '%U:%G' /opt/buildhome)
   assert_equal $owner "buildbot:buildbot"
 }
+
+@test 'NF_IMAGE_VERSION is set and exists' {
+  assert [ -n $NF_IMAGE_VERSION ]
+}
+
+@test 'NF_IMAGE_TAG is set and exists' {
+  assert [ -n $NF_IMAGE_TAG ]
+}
+
+@test 'NF_IMAGE_NAME is set to focal' {
+  assert_equal $NF_IMAGE_NAME "focal"
+}


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Related with https://github.com/netlify/pod-workflow/issues/320. This adds a new env var to the build-image with a codename associated with the build (for now we're going to have `xenial` and `focal`). To be used for logging and debug purposes.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![pinguins](https://media2.giphy.com/media/J2tNIOLEHELkY/giphy.gif?cid=ecf05e47lmixskrnlxcdt2khxodtra717ezb6szs0fxgpxr7&rid=giphy.gif&ct=g)