### PR TITLE
chore: Add additional Go version info

### DIFF
--- a/included_software.md
+++ b/included_software.md
@@ -23,6 +23,7 @@ The specific patch versions included will depend on when the image was last buil
   * 8.0 (default)
 * Go - `GO_VERSION`
   * 1.16 (default)
+  * Any version available on the [Go downloads page](https://golang.org/dl/)
 * Java
   * 8 (default)
 * Emacs


### PR DESCRIPTION
There's no open issue for this. Just a minor change to `included_software.md` that notes any version available on the [Go downloads page](https://golang.org/dl/) as valid.

I'll make a similar PR for Xenial as well.

**A picture of a cute animal (not mandatory, but encouraged)**
![](https://assets.atlasobscura.com/media/W1siZiIsInVwbG9hZHMvYXNzZXRzL2ExNzVjNTFmNzU1YzZmMWU5Y18xMDI0cHgtVHdvX3RvZWRfc2xvdGguSlBHIl0sWyJwIiwiY29udmVydCIsIiJdLFsicCIsImNvbnZlcnQiLCItcXVhbGl0eSA4MSAtYXV0by1vcmllbnQiXSxbInAiLCJ0aHVtYiIsIjc4MHg1MjAjIl1d/1024px-Two_toed_sloth.JPG)