### PR TITLE
chore: Add additional Go version info for Xenial

### DIFF
--- a/included_software.md
+++ b/included_software.md
@@ -25,6 +25,7 @@ The specific patch versions included will depend on when the image was last buil
   * 7.4
 * Go - `GO_VERSION`
   * 1.14.4 (default)
+  * Any version available on the [Go downloads page](https://golang.org/dl/)
 * Java
   * 8 (default)
 * Emacs


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Similar to #677, there's no open issue for this. Just a minor change to included_software.md that notes any version available on the Go downloads page as valid.

**A picture of a cute animal (not mandatory, but encouraged)**
![](https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/xvv2gzljshetmasvpyri.jpg)