### PR TITLE
fix(yarn): add the default installed yarn binary to PATH (xenial)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -255,7 +255,7 @@ RUN curl -o- -L https://yarnpkg.com/install.sh > /usr/local/bin/yarn-installer.s
 
 ENV NVM_VERSION=0.35.3
 
-# Install node.js
+# Install node.js, yarn, grunt, bower and elm
 USER buildbot
 RUN git clone https://github.com/creationix/nvm.git ~/.nvm && \
     cd ~/.nvm && \
@@ -273,6 +273,7 @@ RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
          npm install -g sm grunt-cli bower elm@$ELM_VERSION && \
              bash /usr/local/bin/yarn-installer.sh --version $YARN_VERSION && \
          nvm alias default node && nvm cache clear"
+ENV PATH "/opt/buildhome/.yarn/bin:$PATH"
 
 USER root
 

--- a/tests/node/yarn.bats
+++ b/tests/node/yarn.bats
@@ -27,7 +27,24 @@ teardown() {
   cd - || return
 }
 
-@test 'run_yarn sets up new yarn version if different from the one installed, installs deps and creates cache dir' {
+@test 'yarn 1.22.10 is installed and available by default' {
+  run yarn --version
+  assert_output $YARN_DEFAULT_VERSION
+}
+
+@test 'run_yarn with a new yarn version correctly sets the new yarn binary in PATH' {
+  local newYarnVersion=1.21.0
+  # We can't use bats `run` because environmental changes aren't persisted
+  # We also need to ignore the exit code as the test env is set to return on any non-zero exit code, which we use for
+  # our workspaces checks
+  run_yarn $newYarnVersion || true > /dev/null 2>&1
+
+  # New yarn binary is set in PATH
+  run yarn --version
+  assert_output $newYarnVersion
+}
+
+@test 'run_yarn installs a new yarn version if different from the one installed, installs deps and creates cache dir' {
   local newYarnVersion=1.21.0
   run run_yarn $newYarnVersion
   assert_success


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Same as #682. Currently we don't add the default yarn binary to PATH, meaning we always end up installing the default yarn version on a first run for every build.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [x] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![cat-yarn](https://media4.giphy.com/media/APYioVROaqXnO/giphy.gif?cid=ecf05e47gh98fd7egtguyf7tgh0kui1ublohs5s2azoex9os&rid=giphy.gif&ct=g)
