### PR TITLE
fix: included software link [Focal]

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -207,7 +207,7 @@ check_python_version() {
     echo "Python version set to ${PYTHON_VERSION}"
   else
     echo "Error setting python version from $1"
-    echo "Please see https://github.com/netlify/build-image/blob/focal/included_software.md for current versions"
+    echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
     exit 1
   fi
 }
@@ -436,7 +436,7 @@ install_dependencies() {
       fi
     else
       echo "Error installing Pipenv dependencies"
-      echo "Please see https://github.com/netlify/build-image/blob/focal/included_software.md for current versions"
+      echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
       exit 1
     fi
   fi

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -207,7 +207,7 @@ check_python_version() {
     echo "Python version set to ${PYTHON_VERSION}"
   else
     echo "Error setting python version from $1"
-    echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
+    echo "Please see https://github.com/netlify/build-image/blob/focal/included_software.md for current versions"
     exit 1
   fi
 }
@@ -436,7 +436,7 @@ install_dependencies() {
       fi
     else
       echo "Error installing Pipenv dependencies"
-      echo "Please see https://github.com/netlify/build-image/#included-software for current versions"
+      echo "Please see https://github.com/netlify/build-image/blob/focal/included_software.md for current versions"
       exit 1
     fi
   fi


### PR DESCRIPTION
#### Summary

This PR fixes the broken link to the included software list in the Focal image. Currently it's pointing to https://github.com/netlify/build-image/#included-software. This PR changes it to https://github.com/netlify/build-image/blob/focal/included_software.md.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://user-images.githubusercontent.com/11403551/143243586-fb6e19cd-1598-451d-afc5-07999665389a.png)
