### PR TITLE
fix: set `NETLIFY=true` at the build-image level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -480,6 +480,8 @@ ENV NF_IMAGE_TAG ${NF_IMAGE_TAG:-latest}
 ARG NF_IMAGE_NAME
 ENV NF_IMAGE_NAME ${NF_IMAGE_NAME:-focal}
 
+# CI signal, we set it at image level so that any Buildbot command will inherit this flag
+ENV NETLIFY=true
 
 ################################################################################
 #

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -30,9 +30,6 @@ export PIPENV_RUNTIME=3.8
 export PIPENV_VENV_IN_PROJECT=1
 export PIPENV_DEFAULT_PYTHON_VERSION=3.8
 
-# CI signal
-export NETLIFY=true
-
 YELLOW="\033[0;33m"
 NC="\033[0m" # No Color
 

--- a/tests/base.bats
+++ b/tests/base.bats
@@ -21,3 +21,7 @@ load '../node_modules/bats-assert/load'
 @test 'NF_IMAGE_NAME is set to focal' {
   assert_equal $NF_IMAGE_NAME "focal"
 }
+
+@test 'NETLIFY is set to true' {
+  assert_equal $NETLIFY true
+}


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://github.com/netlify/buildbot/issues/1892. This PR changes the `NETLIFY=true` flag to be exposed at the `build-image` build level, meaning it will be set for all of Buildbot's executions, including calls to the ignore script.
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
