### PR TITLE
fix: Bump Go to 1.17 and omit patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -402,7 +402,7 @@ ENV PATH "$PATH:/opt/buildhome/.gimme/bin"
 ENV GOPATH "/opt/buildhome/.gimme_cache/gopath"
 ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
 # Install the default version
-ENV GIMME_GO_VERSION "1.17"
+ENV GIMME_GO_VERSION "1.17.x"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme | bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -402,7 +402,7 @@ ENV PATH "$PATH:/opt/buildhome/.gimme/bin"
 ENV GOPATH "/opt/buildhome/.gimme_cache/gopath"
 ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
 # Install the default version
-ENV GIMME_GO_VERSION "1.16.5"
+ENV GIMME_GO_VERSION "1.7"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme | bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -402,7 +402,7 @@ ENV PATH "$PATH:/opt/buildhome/.gimme/bin"
 ENV GOPATH "/opt/buildhome/.gimme_cache/gopath"
 ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
 # Install the default version
-ENV GIMME_GO_VERSION "1.7"
+ENV GIMME_GO_VERSION "1.17"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme | bash
 

--- a/included_software.md
+++ b/included_software.md
@@ -22,7 +22,7 @@ The specific patch versions included will depend on when the image was last buil
   * 7.4
   * 8.0 (default)
 * Go - `GO_VERSION`
-  * 1.16 (default)
+  * 1.17 (default)
   * Any version available on the [Go downloads page](https://golang.org/dl/)
 * Java
   * 8 (default)

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -683,13 +683,14 @@ install_dependencies() {
 
   if [ "$GIMME_GO_VERSION" != "$installGoVersion" ]
   then
-    echo "Installing Go version $installGoVersion"
-    GIMME_ENV_PREFIX=$HOME/.gimme_cache/env GIMME_VERSION_PREFIX=$HOME/.gimme_cache/versions gimme $installGoVersion
+    resolvedGoVersion=$(gimme --resolve $installGoVersion)
+    echo "Installing Go version $resolvedGoVersion (requested $installGoVersion)"
+    GIMME_ENV_PREFIX=$HOME/.gimme_cache/env GIMME_VERSION_PREFIX=$HOME/.gimme_cache/versions gimme $resolvedGoVersion
     if [ $? -eq 0 ]
     then
-      source $HOME/.gimme_cache/env/go$installGoVersion.linux.amd64.env
+      source $HOME/.gimme_cache/env/go$resolvedGoVersion.linux.amd64.env
     else
-      echo "Failed to install Go version '$installGoVersion'"
+      echo "Failed to install Go version '$resolvedGoVersion'"
       exit 1
     fi
   else

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -670,40 +670,7 @@ install_dependencies() {
     composer install
   fi
 
-  # Go version
-  restore_home_cache ".gimme_cache" "go cache"
-  if [ -f .go-version ]
-  then
-    local goVersion=$(cat .go-version)
-    if [ "$installGoVersion" != "$goVersion" ]
-    then
-      installGoVersion="$goVersion"
-    fi
-  fi
-
-  if [ "$GIMME_GO_VERSION" != "$installGoVersion" ]
-  then
-    resolvedGoVersion=$(gimme --resolve $installGoVersion)
-    echo "Installing Go version $resolvedGoVersion (requested $installGoVersion)"
-    GIMME_ENV_PREFIX=$HOME/.gimme_cache/env GIMME_VERSION_PREFIX=$HOME/.gimme_cache/versions gimme $resolvedGoVersion
-    if [ $? -eq 0 ]
-    then
-      source $HOME/.gimme_cache/env/go$resolvedGoVersion.linux.amd64.env
-    else
-      echo "Failed to install Go version '$resolvedGoVersion'"
-      exit 1
-    fi
-  else
-    gimme | bash
-    if [ $? -eq 0 ]
-    then
-      source $HOME/.gimme/env/go$GIMME_GO_VERSION.linux.amd64.env
-    else
-      echo "Failed to install Go version '$GIMME_GO_VERSION'"
-      exit 1
-    fi
-  fi
-
+  install_go $installGoVersion
   # Rust
   if [ -f Cargo.toml ] || [ -f Cargo.lock ]
   then
@@ -921,3 +888,42 @@ unset_go_import_path() {
 warn() {
   echo "WARNING: $1"
 }
+
+install_go() {
+  local installGoVersion=$1
+  # Go version
+  restore_home_cache ".gimme_cache" "go cache"
+  if [ -f .go-version ]
+  then
+    local goVersion=$(cat .go-version)
+    if [ "$installGoVersion" != "$goVersion" ]
+    then
+      installGoVersion="$goVersion"
+    fi
+  fi
+
+  if [ "$GIMME_GO_VERSION" != "$installGoVersion" ]
+  then
+    resolvedGoVersion=$(gimme --resolve $installGoVersion)
+    echo "Installing Go version $resolvedGoVersion (requested $installGoVersion)"
+    GIMME_ENV_PREFIX=$HOME/.gimme/env GIMME_VERSION_PREFIX=$HOME/.gimme/versions gimme $resolvedGoVersion
+    if [ $? -eq 0 ]
+    then
+      source $HOME/.gimme/env/go$resolvedGoVersion.linux.amd64.env
+    else
+      echo "Failed to install Go version '$resolvedGoVersion'"
+      exit 1
+    fi
+  else
+    gimme | bash
+    if [ $? -eq 0 ]
+    then
+      source $HOME/.gimme/env/go$GIMME_GO_VERSION.linux.amd64.env
+    else
+      echo "Failed to install Go version '$GIMME_GO_VERSION'"
+      exit 1
+    fi
+  fi
+
+}
+

--- a/run-build.sh
+++ b/run-build.sh
@@ -21,7 +21,7 @@ cd $NETLIFY_REPO_DIR
 : ${NODE_VERSION="16"}
 : ${RUBY_VERSION="2.7.2"}
 : ${YARN_VERSION="1.22.10"}
-: ${GO_VERSION="1.17.5"}
+: ${GO_VERSION="1.17"}
 : ${PYTHON_VERSION="3.8"}
 
 echo "Installing dependencies"

--- a/run-build.sh
+++ b/run-build.sh
@@ -21,7 +21,7 @@ cd $NETLIFY_REPO_DIR
 : ${NODE_VERSION="16"}
 : ${RUBY_VERSION="2.7.2"}
 : ${YARN_VERSION="1.22.10"}
-: ${GO_VERSION="1.16.5"}
+: ${GO_VERSION="1.17.5"}
 : ${PYTHON_VERSION="3.8"}
 
 echo "Installing dependencies"

--- a/tests/go/base.bats
+++ b/tests/go/base.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load "../helpers.sh"
+
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
+load '../../node_modules/bats-file/load'
+
+setup() {
+  # Load functions
+  load '../../run-build-functions.sh'
+}
+
+@test 'go version 1.17 at the latest patch is installed and available at startup by default' {
+  run install_go
+  assert_success
+  # we can't specify which patch version because it will change
+  assert_output --partial "Installing Go version 1.17."
+  assert_output --partial "go version go1.17."
+}
+
+@test 'install custom go version' {
+  local customGoVersion=1.16.4
+  run install_go $customGoVersion
+  assert_success
+  assert_output --partial "Installing Go version 1.16.4"
+  assert_output --partial "go version go1.16.4 linux/amd64"
+}


### PR DESCRIPTION
#### Summary

1. Bump to latest Go minor version
2. Omit the patch version. By omitting the patch version, the latest 1.7.x will be used, which helps ensure that security fixes are brought in automatically.

