### PR TITLE
fix: ci xenial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,8 +142,6 @@ RUN apt-get -y update && \
         python-dev \
         python3 \
         python3-dev \
-        python3.7 \
-        python3.7-dev \
         rlwrap \
         rsync \
         software-properties-common \
@@ -285,6 +283,16 @@ USER root
 
 ENV PIPENV_RUNTIME 2.7
 
+# install Python3.7 through pyenv as it is no longer available packaged for xenial
+RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer \
+    | bash
+RUN git clone git://github.com/pyenv/pyenv.git /tmp/pyenv && \
+    cd /tmp/pyenv/plugins/python-build && \
+    ./install.sh && \
+    rm -rf /tmp/pyenv
+
+RUN python-build 3.7.2 /opt/buildhome
+
 USER buildbot
 
 RUN virtualenv -p python2.7 --no-site-packages /opt/buildhome/python2.7 && \
@@ -295,7 +303,7 @@ RUN virtualenv -p python3.5 --no-site-packages /opt/buildhome/python3.5 && \
     /bin/bash -c 'source /opt/buildhome/python3.5/bin/activate' && \
     ln -nfs /opt/buildhome/python3.5 /opt/buildhome/python3.5.6
 
-RUN virtualenv -p python3.7 --no-site-packages /opt/buildhome/python3.7 && \
+RUN virtualenv -p /opt/buildhome/bin/python3.7 --no-site-packages /opt/buildhome/python3.7 && \
     /bin/bash -c 'source /opt/buildhome/python3.7/bin/activate' && \
     ln -nfs /opt/buildhome/python3.7 /opt/buildhome/python3.7.2
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #731 

The deadsnakes package which we are using to download older versions of python no longer supports Python 3.7 on Xenial.
This changes it to download and install python 3.7 by downloading `pyenv` and then using it's `python-build` tool.

I haven't included python-build in the included software doc. Not sure if it should be?

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- ~Update or add tests (if any source code was changed or added) 🧪~
- ~Update the [included software doc](../included_software.md) (if you updated included software) 📄~
- ~Update or add documentation (if features were changed or added) 📝~
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://user-images.githubusercontent.com/7613966/151161198-e79b7efc-7e54-4f77-a9aa-83e5d76d50a2.png)

