### PR TITLE
chore: remove graphicsmagick apt-repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get -y update && \
     apt-add-repository -y -s 'deb https://packagecloud.io/github/git-lfs/ubuntu/ xenial main' && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
     add-apt-repository -y ppa:git-core/ppa && \
-    add-apt-repository -y ppa:rwky/graphicsmagick && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:kelleyk/emacs && \
     apt-add-repository -y 'deb https://packages.erlang-solutions.com/ubuntu xenial contrib' && \


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

The Xenial CI was failing because the ppa rwky/graphicsmagick [no longer seems to exist](https://launchpad.net/~rwky/+archive/ubuntu/graphicsmagick). We can just install it directly with apt-get though.

---

For us to review and ship your PR efficiently, please perform the following steps:

~~Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.~~
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
~~Update or add tests (if any source code was changed or added) 🧪~~
~~Update the [included software doc](../included_software.md) (if you updated included software) 📄~~
~~Update or add documentation (if features were changed or added) 📝~~
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**


![](http://slappedham.com/wp-content/uploads/2015/04/Waving-Bear1.jpg)

