### PR TITLE
fix: `pyenv` should use HTTPS to git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,7 +285,7 @@ ENV PIPENV_RUNTIME 2.7
 # install Python3.7 through pyenv as it is no longer available packaged for xenial
 RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer \
     | bash
-RUN git clone git://github.com/pyenv/pyenv.git /tmp/pyenv && \
+RUN git clone https://github.com/pyenv/pyenv.git /tmp/pyenv && \
     cd /tmp/pyenv/plugins/python-build && \
     ./install.sh && \
     rm -rf /tmp/pyenv


### PR DESCRIPTION
Since yesterday (2022-03-15), GitHub [does not support the `git:` protocol anymore](https://github.blog/2021-09-01-improving-git-protocol-security-github/).

As a consequence, our [CI currently fails](https://app.circleci.com/pipelines/github/netlify/build-image/311/workflows/7ef0ac68-186a-430f-9afd-f34780c2466b/jobs/850):

```
Step 33/122 : RUN git clone git://github.com/pyenv/pyenv.git /tmp/pyenv &&     cd /tmp/pyenv/plugins/python-build &&     ./install.sh &&     rm -rf /tmp/pyenv
 ---> Running in 05f14de4a2ea
Cloning into '/tmp/pyenv'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
The command '/bin/sh -c git clone git://github.com/pyenv/pyenv.git /tmp/pyenv &&     cd /tmp/pyenv/plugins/python-build &&     ./install.sh &&     rm -rf /tmp/pyenv' returned a non-zero code: 128

Exited with code exit status 128
```

This is only a problem for the `xenial` branch, since pyenv is not present in the `focal` one.

The Dockerfile does not contain any other usage of the `git:` protocol.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅