### PR TITLE
feat: replace `EXPERIMENTAL_NPM_WORKSPACES_CACHING` with a LaunchDarkly feature flag

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -77,7 +77,8 @@ mkdir -p $NETLIFY_CACHE_DIR/.cargo
 # have escaped commas in their value. Otherwise, parsing the list as an array,
 # e.g. using `IFS="," read -ra <<<"$1"` would be needed.
 has_feature_flag() {
-  if [[ "${1}," == *"${2},"* ]]; then
+  if [[ "${1}," == *"${2},"* ]]
+  then
     return 0
   else
     return 1
@@ -183,7 +184,9 @@ run_npm_set_temp() {
 }
 
 run_npm() {
-  if [ -n "$EXPERIMENTAL_NPM_WORKSPACES_CACHING" ]
+  local featureFlags="$1"
+
+  if [ -n "$EXPERIMENTAL_NPM_WORKSPACES_CACHING" ] || has_feature_flag "$featureFlags" "build_image_npm_workspaces_caching"
   then
     restore_node_modules "npm"
   else
@@ -542,7 +545,7 @@ install_dependencies() {
     then
       run_yarn $YARN_VERSION
     else
-      run_npm
+      run_npm "$featureFlags"
     fi
   fi
 


### PR DESCRIPTION
This replaces the `EXPERIMENTAL_NPM_WORKSPACES_CACHING` variable currently used as a feature flag. At the moment, it is an environment variable. Instead, this PR replaces it with [a LaunchDarkly flag](https://app.launchdarkly.com/default/production/features/build_image_npm_workspaces_caching/targeting).

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅