### PR TITLE
add webm to the default fetchinclude

### DIFF
--- a/buildbot-git-config
+++ b/buildbot-git-config
@@ -1,5 +1,5 @@
 [lfs]
-	fetchinclude = *.jpg,*.png,*.jpeg,*.svg,*.gif,*.pdf,*.mp4,*.bmp,*.webp
+	fetchinclude = *.jpg,*.png,*.jpeg,*.svg,*.gif,*.pdf,*.mp4,*.bmp,*.webp,*.webm
 [filter "lfs"]
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f


### PR DESCRIPTION
#### Summary

Fixes https://github.com/netlify/build-image/issues/777

This PR adds `webm` files to the default `fetchinclude`. This means that users who are making use of LFS and have `webm` video files won't have issues when deploying sites 👍 

I struggled for about a week trying to find the exact set of levers to pull to make LFS work with my site and I came across this thread that ultimately solved the issue: https://answers.netlify.com/t/webm-not-working-under-git-hub-lfs/14460/4

My reasoning for opening this PR is that I'm assuming (possibly naively) that this can't hurt anyone's existing sites, and it just unblocks people that happen to be using LFS with `webm` files.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
~- [ ] Update or add tests (if any source code was changed or added) 🧪~
~- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄~
~- [ ] Update or add documentation (if features were changed or added) 📝~
- [ ] Make sure the status checks below are successful ✅

So I have made the only check that I have control over pass 🤔 I don't know how to make the label check pass since I'm not able to label this PR 🤔 

**A picture of a cute animal (not mandatory, but encouraged)**

My profile pic has a cute animal in it 😉 his name is Rodney 🐶 
