### PR TITLE
Use an up-to-date docker image for the lint command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 orbs:
-  docker: circleci/docker@1.7
+  docker: circleci/docker@2.1.1
 
 commands:
   setup-remote-docker-with-experimental-feats:


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Circle CI no longer supports Ubuntu 16.04. Although our CI doesn't generally use it for focal, the lint command was using an out of date image which was affected.



<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
