### PR TITLE
Copy the ruby version into rvm/gems

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -336,6 +336,7 @@ install_dependencies() {
     echo "Started restoring cached ruby version"
     rm -rf $RVM_DIR/rubies/${fulldruby}
     cp -p -r $NETLIFY_CACHE_DIR/ruby_version/${fulldruby} $RVM_DIR/rubies/
+    cp -p -r $NETLIFY_CACHE_DIR/ruby_version/${fulldruby} $RVM_DIR/gems/
     echo "Finished restoring cached ruby version"
   fi
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Several customers have reported this error when running cached builds using ruby 3.1.2: ` /opt/buildhome/.rvm/gems/ruby-3.1.2/bin/bundle: 6: exec: /opt/buildhome/.rvm/gems/ruby-3.1.2/bin/ruby: not found`

The issue is that bundler is now looking for the ruby binary in ` /opt/buildhome/.rvm/gems` and we install it in `/opt/buildhome/.rvm/rubies`. I've updated the build script to now copy it into both locations as I'm concerned removing it from `rubies` may break older versions, although I guess it will make the build image bigger 🐼 
I can't pinpoint what update has caused this out of ruby, bundler or rvm (my money is on bundler though).

Fixes: [Unable to use Ruby 3.1.2 in builds](https://github.com/netlify/pillar-workflow/issues/558)

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://user-images.githubusercontent.com/7613966/174317809-682d39ec-57b1-4790-9067-4a2928aa8e79.png)
