### PR TITLE
fix: create missing /opt/build directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -462,7 +462,7 @@ ENV PATH "$PATH:/opt/buildhome/.cargo/bin"
 USER root
 
 # Add buildscript for local testing
-RUN mkdir -p /opt/build-bin
+RUN mkdir -p /opt/build /opt/build-bin
 ADD run-build-functions.sh /opt/build-bin/run-build-functions.sh
 ADD run-build.sh /opt/build-bin/build
 ADD buildbot-git-config /root/.gitconfig


### PR DESCRIPTION

Fixes #794 

[adds `/opt/build` to the `mkdir` step of the build-image dockerfile
](https://github.com/lvwvm/netlify-build-image/commit/f576b478ddf9e67bf58ebe7852ec7f6aae250fb2)

---

**A picture of a cute animal**

![image](https://user-images.githubusercontent.com/3513564/174684327-a42ab0b0-932c-48b0-aea7-4994532996cd.png)
