### PR TITLE
feat: add musl libc and its tools to build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,10 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libvips-tools \
         libyaml-dev \
         mercurial \
+        # musl and musl-tools are needed for certain rust dependencies (ring) to compile correctly
+        # see https://github.com/netlify/pillar-runtime/issues/401
+        musl \
+        musl-tools \
         nasm \
         openjdk-8-jdk \
         optipng \

--- a/focal.yaml
+++ b/focal.yaml
@@ -150,3 +150,9 @@ commandTests:
     args: ["--version"]
     expectedOutput:
       - rustup 1\.\d+\.\d+
+
+  - name: "Musl library and its tools are available"
+    command: "musl-gcc"
+    args: ["--version"]
+    expectedOutput:
+      - Ubuntu 9\.4\.\d+ # version of gcc, as musl-gcc is just a wrapper


### PR DESCRIPTION
#### Summary

We had a [customer report](https://answers.netlify.com/t/building-ring-crate-for-rust-based-function/64265) that they weren't able to have their rust function compiled in our build pipeline. As it turned out they use the crate `ring` which requires `musl-gcc` to compile itself. 

Now the obvious fix would be to have musl dependencies available (which is what I am doing in this PR). I'm not sure though if we actually want to have musl available in the build-image? To me it seems to make sense to have the musl-tools in the build environment, because we [tell people to use musl](https://www.netlify.com/blog/2021/10/14/write-netlify-functions-in-rust/#deployment) and also [do it by default](https://github.com/netlify/zip-it-and-ship-it/blob/main/src/runtimes/rust/constants.ts#L1). In theory glibc would work as well, as[ we use Amazon Linux 2](https://github.com/netlify/bitballoon/blob/00a35db65833350530f4092ef000362572db1608/app/models/cloud_function/aws_lambda.rb#L22), so glibc [is new enough for rust](https://github.com/awslabs/aws-lambda-rust-runtime/discussions/306#discussioncomment-485478).

I wasn't able to really reproduce to compile `ring`, because rust is segfaulting when I try to run it inside the build image (amd64) on my m1 host.

Do I need to include musl/musl-tools in the included_software.md? I don't see gcc there either so I wasn't sure if musl-tools would count as a tool.

The new additional packages are: `musl, musl-dev, musl-tools`

Fixes netlify/pillar-runtime#401

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
