### PR TITLE
fix: update test to reflect new homebrew version

### DIFF
--- a/focal-amd64.yaml
+++ b/focal-amd64.yaml
@@ -18,4 +18,4 @@ commandTests:
     command: "brew"
     args: ["--version"]
     expectedOutput:
-      - Homebrew 3\.5\.\d+
+      - Homebrew 3\.6\.\d+


### PR DESCRIPTION
#### Summary

Fixes failing test in amd64.

Homebrew has released a new minor version, and as we're installing from HEAD we should reflect that in the tests.

