### PR TITLE
feat: Update Emacs to version 28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     update-locale en_US.UTF-8 && \
     add-apt-repository -y ppa:ondrej/php && \
     add-apt-repository -y ppa:git-core/ppa && \
+    add-apt-repository -y ppa:kelleyk/emacs && \
     apt-get -y update && \
     apt-get install -y --no-install-recommends \
         advancecomp \
@@ -47,7 +48,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         cmake \
         doxygen \
         elixir \
-        emacs-nox \
+        emacs28-nox \
         expect \
         file \
         fontconfig \

--- a/included_software.md
+++ b/included_software.md
@@ -27,7 +27,7 @@ The specific patch versions included will depend on when the image was last buil
 * Java
   * 8 (default)
 * Emacs
-  * 26.3 (default)
+  * 28.1 (default)
 * Erlang
   * 22.2 (default)
 * Elixir


### PR DESCRIPTION
Fixes https://github.com/netlify/build-image/issues/782.

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #782.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

This PR is necessary because I have started facing Emacs package build dependency issues when building some sites that rely on Emacs. The current default Emacs version 26.3 is more than 3 years old. This PR bumps up the Emacs version to 28.1 that got released in April 2022.

![image](https://user-images.githubusercontent.com/3578197/194596760-1b5ad37c-f946-459f-9a6e-293519b5101b.png)


---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [x] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://user-images.githubusercontent.com/3578197/194596397-ee97ca8f-2c37-48bc-8c66-c06b3d728fce.png)
