### PR TITLE
chore: Remove Xenial references in the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ If required, someone with write accesss to the repo can trigger the push for you
 
 ## Releasing
 
-1. Create two PRs, one branching off `focal` and one branching off `xenial`, with your changes applied to each.
-2. Once the PRs are approved, merge them into their respective base branches. The merge commit should also follow the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary).
+1. Create a PR branching off of `focal` with your changes applied.
+2. Once the PR is approved, merge it into the respective base branch. The merge commit should also follow the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary).
 3. Commits which are prefaced with `fix:` or `feat:` will trigger package release PRs created by [release-please](https://github.com/googleapis/release-please). Merge these PRs. If you need to manually trigger a release-please PR you can bump the version by creating an [empty PR](https://github.com/netlify/build-image/pull/728).
 4. Wait for the CI pipelines to finish. Renovate should automatically create a PR in `buildbot` with the latest `build-image` releases (this may not happen straight away, but you can speed it up by checking [the box in the dependency dashboard](https://github.com/netlify/buildbot/issues/912) or manually create a PR to bump [the version](https://github.com/netlify/buildbot/blob/0ada244ab84a1759a70d6b2cfc27c9987b5c77ca/.circleci/config.yml#L141-L150)).
 5. Review, test and deploy the PR in `buildbot`.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ If you're having problems with your build, you can also use these tools to test 
 
 Netlify maintains multiple build images for testing new development as well as supporting legacy builds. Each image uses a different version of Ubuntu Linux, with a slightly different list of included language and software versions.
 
-The following images are currently available:
+The following image is currently available:
 
 - `focal` - Default build image for all new sites; Running Ubuntu 20.04 and [this software](https://github.com/netlify/build-image/blob/focal/included_software.md)
-- `xenial` - Build image for existing sites; running Ubuntu 16.04 and [this software](https://github.com/netlify/build-image/blob/xenial/included_software.md)
 
 Each image name above corresponds to a branch in this repository.
 


### PR DESCRIPTION
Remove references to 'Xenial' from the repo now that Xenial is going to be EOL.

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Part of the Xenial Build Image Deprecation Project

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step. **There is no bug/issue in this repo for this work**
- [X] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [X] Update or add tests (if any source code was changed or added) 🧪
- [X] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [X] Update or add documentation (if features were changed or added) 📝
- [X] Make sure the status checks below are successful ✅


![Sloth](https://user-images.githubusercontent.com/1085586/201808358-5def498c-986b-41f4-ae42-8c7fc29f6c3c.jpg)




