### PR TITLE
fix: Bump Go to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -458,7 +458,7 @@ ENV PATH "$PATH:/opt/buildhome/.gimme/bin"
 ENV GOPATH "/opt/buildhome/.gimme_cache/gopath"
 ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
 # Install the default version
-ENV GIMME_GO_VERSION "1.17.x"
+ENV GIMME_GO_VERSION "1.19.x"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
 RUN gimme | bash
 

--- a/included_software.md
+++ b/included_software.md
@@ -22,7 +22,7 @@ The specific patch versions included will depend on when the image was last buil
   * 7.4
   * 8.0 (default)
 * Go - `GO_VERSION`
-  * 1.17 (default)
+  * 1.19 (default)
   * Any version available on the [Go downloads page](https://golang.org/dl/)
 * Java
   * 8 (default)

--- a/included_software.md
+++ b/included_software.md
@@ -22,7 +22,7 @@ The specific patch versions included will depend on when the image was last buil
   * 7.4
   * 8.0 (default)
 * Go - `GO_VERSION`
-  * 1.19 (default)
+  * latest 1.19.x (default)
   * Any version available on the [Go downloads page](https://golang.org/dl/)
 * Java
   * 8 (default)

--- a/run-build.sh
+++ b/run-build.sh
@@ -33,7 +33,7 @@ cd "$NETLIFY_REPO_DIR/$NETLIFY_PACKAGE_DIR" || exit
 : "${RUBY_VERSION="2.7.2"}"
 : "${YARN_VERSION="1.22.19"}"
 : "${PNPM_VERSION="7.13.4"}"
-: "${GO_VERSION="1.17"}"
+: "${GO_VERSION="1.19"}"
 : "${PYTHON_VERSION="3.8"}"
 : "${BUILD_INFO="$defaultBuildInfo"}"
 : "${FEATURE_FLAGS="build-image_use_new_package_manager_detection"}"

--- a/run-build.sh
+++ b/run-build.sh
@@ -33,7 +33,7 @@ cd "$NETLIFY_REPO_DIR/$NETLIFY_PACKAGE_DIR" || exit
 : "${RUBY_VERSION="2.7.2"}"
 : "${YARN_VERSION="1.22.19"}"
 : "${PNPM_VERSION="7.13.4"}"
-: "${GO_VERSION="1.19"}"
+: "${GO_VERSION="1.19.x"}"
 : "${PYTHON_VERSION="3.8"}"
 : "${BUILD_INFO="$defaultBuildInfo"}"
 : "${FEATURE_FLAGS="build-image_use_new_package_manager_detection"}"

--- a/tests/go/base.bats
+++ b/tests/go/base.bats
@@ -11,12 +11,12 @@ setup() {
   load '../../run-build-functions.sh'
 }
 
-@test 'go version 1.17 at the latest patch is installed and available at startup by default' {
+@test 'go version 1.19 at the latest patch is installed and available at startup by default' {
   run install_go
   assert_success
   # we can't specify which patch version because it will change
-  assert_output --partial "Installing Go version 1.17."
-  assert_output --partial "go version go1.17."
+  assert_output --partial "Installing Go version 1.19."
+  assert_output --partial "go version go1.19."
 }
 
 @test 'install custom go version' {


### PR DESCRIPTION
#### Summary

What I noticed is that we install the latest patch version with `1.19.x` but then always use and also freeze (in bitballoon) 1.19 version. So we never actually use the latest patch version. Should we also freeze and use `1.19.x` by default? That though would mean that new sites that have `1.19.x` frozen will automatically get patch updates installed.

If we freeze 1.19 we should also install 1.19 and not the latest patch version of 1.19.x

Ref: netlify/bitballoon#13837

Fixes: https://github.com/netlify/pod-compute/issues/188

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
