### PR TITLE
chore: replace xenial with focal in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Emulating Netlify's buildbot on your local machine requires the following:
 Open your Docker terminal, and run the following command to pull the default image:
 
 ```
-docker pull netlify/build:xenial
+docker pull netlify/build:focal
 or
 docker pull netlify/build:v3.0.2 # replace the version with a git tag of the specific version you want to test
 ```


### PR DESCRIPTION
docs: Update README to no longer refer to xenial
#### Summary

Following the steps in the `README.md` to the letter leads to downloading the docker image twice. Once for xenial (which is no longer supported by Netlify builds) and once for focal (in Step 2, once `./test-tools/start-image.sh path/to/site/repo` is executed).

This commit removes mention of the `netlify/build:focal` image to align this with step two.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

![Long-tailed tit](https://live.staticflickr.com/65535/52350747194_8ebd8e65d2_c_d.jpg)
