### PR TITLE
fix: ensure that go is always correctly installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -468,6 +468,8 @@ ENV GOCACHE "/opt/buildhome/.gimme_cache/gocache"
 # Install the default version
 ENV GIMME_GO_VERSION "1.19.x"
 ENV GIMME_ENV_PREFIX "/opt/buildhome/.gimme/env"
+ENV GIMME_VERSION_PREFIX "/opt/buildhome/.gimme/versions"
+ENV GIMME_TYPE "binary"
 RUN gimme | bash
 
 ################################################################################

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -1014,8 +1014,15 @@ install_go() {
       installGoVersion="$goVersion"
     fi
   fi
+
   # Cache known version for 7days (604800 seconds)
-  resolvedGoVersion=$(GIMME_KNOWN_CACHE_MAX=604800 gimme --resolve $installGoVersion)
+  resolvedGoVersion="$(GIMME_KNOWN_CACHE_MAX=604800 gimme --resolve $installGoVersion)"
+  if [ $? -ne 0 ]
+  then
+    echo "Failed to resolve Go version '$installGoVersion'"
+    exit 1
+  fi
+
   gimmeEnvFile=$HOME/.gimme/env/go$resolvedGoVersion.linux.$(dpkg --print-architecture).env
 
   # Check if the version is already installed by gimme

--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -1014,29 +1014,21 @@ install_go() {
       installGoVersion="$goVersion"
     fi
   fi
+  # Cache known version for 7days (604800 seconds)
+  resolvedGoVersion=$(GIMME_KNOWN_CACHE_MAX=604800 gimme --resolve $installGoVersion)
+  gimmeEnvFile=$HOME/.gimme/env/go$resolvedGoVersion.linux.$(dpkg --print-architecture).env
 
-  if [ "$GIMME_GO_VERSION" != "$installGoVersion" ]
+  # Check if the version is already installed by gimme
+  if [ ! -f $gimmeEnvFile ]
   then
-    resolvedGoVersion=$(gimme --resolve $installGoVersion)
     echo "Installing Go version $resolvedGoVersion (requested $installGoVersion)"
     GIMME_ENV_PREFIX=$HOME/.gimme/env GIMME_VERSION_PREFIX=$HOME/.gimme/versions gimme $resolvedGoVersion
-    if [ $? -eq 0 ]
+    if [ $? -ne 0 ]
     then
-      source $HOME/.gimme/env/go$resolvedGoVersion.linux.$(dpkg --print-architecture).env
-    else
       echo "Failed to install Go version '$resolvedGoVersion'"
-      exit 1
-    fi
-  else
-    gimme | bash
-    if [ $? -eq 0 ]
-    then
-      source $HOME/.gimme/env/go$GIMME_GO_VERSION.linux.amd64.env
-    else
-      echo "Failed to install Go version '$GIMME_GO_VERSION'"
       exit 1
     fi
   fi
 
+  source $gimmeEnvFile
 }
-

--- a/tests/go/base.bats
+++ b/tests/go/base.bats
@@ -29,6 +29,14 @@ setup() {
   assert_output --partial "go version go1.19."
 }
 
+@test 'an unresolvable go version fails script' {
+  run install_go "notaversion"
+  assert_failure
+  assert_output --partial "Failed to resolve Go version 'notaversion'"
+  refute_output --partial "Installing Go version"
+  refute_output --partial "go version go"
+}
+
 @test 'install custom go version' {
   local customGoVersion=1.16.4
   run install_go $customGoVersion

--- a/tests/go/base.bats
+++ b/tests/go/base.bats
@@ -15,7 +15,17 @@ setup() {
   run install_go
   assert_success
   # we can't specify which patch version because it will change
-  assert_output --partial "Installing Go version 1.19."
+  # Also no message about installation will be shown because it is the default already installed version
+  refute_output --partial "Installing Go version 1.19."
+  assert_output --partial "go version go1.19."
+}
+
+@test 'go version 1.19 at the latest patch is installed and available at startup by default when specifying default version' {
+  run install_go $GIMME_GO_VERSION
+  assert_success
+  # we can't specify which patch version because it will change
+  # Also no message about installation will be shown because it is the default already installed version
+  refute_output --partial "Installing Go version 1.19."
   assert_output --partial "go version go1.19."
 }
 


### PR DESCRIPTION
#### Summary

Fixes https://github.com/netlify/pillar-workflow/issues/1025

When installing go we always checked if `GIMME_GO_VERSION` (default installed version in docker `1.19.x`) does not equal `installGoVersion` (users version from `GO_VERSION` or default 1.19.x).

If they do not equal we would resolve `installGoVersion` and install it by calling gimme.

Otherwise we would install the version from `GIMME_GO_VERSION`.

Checking the history `GIMME_GO_VERSION` was always identical to the default `installGoVersion` unless the user changed it, but in #870 both default value were changed to be `1.19.x`. Two problems with that:

- We tried to source the env file with `GIMME_GO_VERSION` (the unresolved version), but gimme always resolves before installing, so there is no env file for 1.19.x (this seems to have been broken since #870)
- Now that 1.19.4 was released, 1.19.x resolves to it, but in the build-image we have 1.19.3 installed.

The change simplifies the code and always checks if the actual resolved version from `installGoVersion` is already installed or not. GIMME_GO_VERSION is not used anymore as it really does not matter, either the requested go version is installed or not.

This has one downside though: we always call `gimme --resolve` which goes to network for `.x` versions, but caches known versions for 3 hours by default, I changed that to 7 days, but that is debatable. That means that when `1.19.5` is released it might take up to a week before users with a go version of `1.19.x` will get that new version. ([The actual check in gimme](https://github.com/travis-ci/gimme/blob/master/gimme#L689) uses the file creation time, so I do hope our caching preserves file creation times)

~~What I did not understand what `gimme | bash` was supposed to do? It installs GIMME_GO_VERSION by default, but why the pipe to bash?~~ gimme returns a bash script, so the `source` call we had in the script did source the script a second time.

The alternative is to simply revert all the default versions from 1.19.x to 1.19.4, BUT bitballon currently freezes 1.19.x to new user accounts, so in any way the builds would get a `installGoVersion` of 1.19.x

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
