### PR TITLE
fix: ensure that .netlify is a directory and not a file or broken symlink

### DIFF
--- a/run-build-functions.sh
+++ b/run-build-functions.sh
@@ -394,6 +394,8 @@ install_dependencies() {
   # Automatically installed Build plugins
   if [ ! -d "$PWD/.netlify" ]
   then
+    # It might be a file or a broken symlink, so let's remove it before creating it
+    rm -rf "$PWD/.netlify"
     mkdir "$PWD/.netlify"
   fi
   restore_cwd_cache ".netlify/plugins" "build plugins"


### PR DESCRIPTION
#### Summary

Fixes https://app.bugsnag.com/netlify/netlify-build/errors/63b6daab56c5cf00082ee11f?event_id=63b6daab00a2f84cc76b0000&i=sk&m=nw

Also in the build log of the affected build I can see: 

```
3:10:59 PM: mkdir: cannot create directory ‘/opt/build/repo/.netlify’: File exists
3:10:59 PM: Started restoring cached build plugins
3:10:59 PM: mv: failed to access '/opt/build/repo/.netlify/plugins': Not a directory
3:10:59 PM: Finished restoring cached build plugins
```

It seems some repos have `.netlify` as a file. For example: https://github.com/MailTape/MailTape.github.io/blob/master/.netlify
Is this an old format of the config file? What is that? To me this looks like the CLI global config file.

This change ensures that if `.netlify` is not a directory we remove it before we try to create it.

Alternatively, we could also error the build if the file is present? 

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/build-image/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update the [included software doc](../included_software.md) (if you updated included software) 📄
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
